### PR TITLE
add GHA go test reporter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         shell: bash
       - name: Run Go tests and generate in json format
         run: go test -json -v ./... | tee report.json
+        shell: bash
       - name: Publish Test Report
         uses: dorny/test-reporter@fe45e9537387dac839af0d33ba56eed8e24189e8
         with:


### PR DESCRIPTION
## Pull request overview

This PR adds test reporting capabilities for Go tests in the CI workflow by integrating the dorny/test-reporter action. The changes enable better visibility of test results by generating JSON-formatted test output and publishing formatted test reports.

- Generates JSON-formatted test output using `go test -json`
- Integrates dorny/test-reporter action to publish formatted test reports
- Applies changes to both Linux and Windows build jobs

<img width="792" height="821" alt="image" src="https://github.com/user-attachments/assets/9785dc06-6d74-4034-93d3-0d49baf39e24" />
