### PR TITLE
copy LICENSE file on bootstrap

### DIFF
--- a/cmd/dpm/cmd/repo_test.go
+++ b/cmd/dpm/cmd/repo_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	root "daml.com/x/assistant"
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/licenseutils"
 	"daml.com/x/assistant/pkg/ocilister"
@@ -91,6 +92,12 @@ func (suite *RepoSuite) TestRepoCreateTarball() {
 			entries, err := os.ReadDir(dir)
 			require.NoError(t, err)
 			verifyLnkAtPath(t, filepath.Join(dir, entries[0].Name()))
+		})
+		t.Run("verify LICENSE file", func(t *testing.T) {
+			licenseFile := filepath.Join(tmpDamlHome, "cache", "components", "dpm", "4.5.6", "LICENSE")
+			bytes, err := os.ReadFile(licenseFile)
+			require.NoError(t, err)
+			assert.Equal(t, bytes, root.License)
 		})
 	})
 

--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2017-2025 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package root
+
+import _ "embed"
+
+//go:embed LICENSE
+var License []byte


### PR DESCRIPTION
Copy embedded `LICENSE` file into `$DPM_HOME/cache/components/dpm/<version>/` at the time of `dpm bootstrap`.

Note that `bootstrap` only runs once, namely when installing a tarball, and doesn't run when `dpm install <sdk version>`.
**This means only the first `dpm` version under `$DPM_HOME/cache/components/dpm/` will have the LICENSE file, but later ones obtained via `dpm install` won't!**