### PR TITLE
non-admin DPM installation docs

### DIFF
--- a/docs/src/public/configuration.rst
+++ b/docs/src/public/configuration.rst
@@ -36,6 +36,10 @@ DAML_PACKAGE            allows running ``dpm`` commands in a package context wit
 DPM_SDK_VERSION         allows overriding the SDK version being used. It's a global override that overrides the sdk version specified in any and all daml.yaml(s). It also overrides the SDK version used outside package or multi-package context. It doesn't affect the behavior of the `install` command(s)
 ======================= ====================================================================================================================================
 
+Additionally, DPM (and DPM's installation process) make use of the system's default temp directory.
+On Unix systems, it uses ``$TMPDIR`` if non-empty, else ``/tmp``.
+On Windows, it uses ``GetTempPath``, returning the first non-empty value from ``%TMP%``, ``%TEMP%``, ``%USERPROFILE%``, or the ``Windows`` directory.
+
 Project Configuration
 *********************
 

--- a/docs/src/public/manual-install.rst
+++ b/docs/src/public/manual-install.rst
@@ -54,9 +54,15 @@ Download and unpack the latest dpm sdk version's `archive (.zip) <https://get.di
 
 .. code:: powershell
 
-    # Extract the downloaded zip ($ZIP_PATH) to temp directory
-    $EXTRACTED = Join-Path "$env:TEMP" "extracted"
+    # Extract the downloaded zip ($ZIP_PATH) to temp directory ($EXTRACTED)
+    # Avoid using the system's temp directory as the user may not have rights to it
     New-Item -ItemType Directory -Path $EXTRACTED | Out-Null
     Expand-Archive -Path $ZIP_PATH -DestinationPath $EXTRACTED
     
+    # Optionally, override the TMP and DPM_HOME environment variable to point to directories other than the default,
+    # as the user might not have rights to the default directories.
+    # (You might also want to persist these variables as DPM uses them on every invocation)
+    $env:TMP = "<user-owned temporary directory>"
+    $env:DPM_HOME = "<user-owned directory>"
+
     & "$EXTRACTED\windows-amd64\bin\dpm.exe" bootstrap $EXTRACTED\windows-amd64


### PR DESCRIPTION
- Include docs about dpm's temp dir usage
- Modify "manual installation instructions" for windows to work for non-admin user accounts