### PR TITLE
Add skip-existing flag to publish components cmd

### DIFF
--- a/cmd/dpm/cmd/repo/component/component.go
+++ b/cmd/dpm/cmd/repo/component/component.go
@@ -45,6 +45,7 @@ func Cmd() *cobra.Command {
 				AuthFilePath:   c.RegistryAuth,
 				Insecure:       c.Insecure,
 				ExtraTags:      c.ExtraTags,
+				SkipExisting:   c.SkipExisting,
 			}
 			return publish.New(publishConfig, cmd).Publish(cmd.Context())
 		},
@@ -62,6 +63,7 @@ func Cmd() *cobra.Command {
 	cmd.Flags().StringVar(&c.Registry, "registry", "", "OCI registry to use for pushing")
 	cmd.Flags().BoolVar(&c.Insecure, "insecure", false, "use http instead of https for OCI registry")
 	cmd.Flags().StringVar(&c.RegistryAuth, "auth", "", "path to a config file similar to docker’s config.json to use for authenticating to the OCI registry. Defaults to docker's config.json")
+	cmd.Flags().BoolVar(&c.SkipExisting, "skip-existing", false, "skip publishing of existing versions of a component")
 
 	return cmd
 }

--- a/cmd/dpm/cmd/repo_test.go
+++ b/cmd/dpm/cmd/repo_test.go
@@ -299,6 +299,24 @@ func publishComponents(t *testing.T, extraTags ...string) {
 		require.NoError(t, cmd.Execute())
 	})
 
+	t.Run("publish component skipping existing", func(t *testing.T) {
+		cmd := createStdTestRootCmd(t)
+		if extraTags == nil || len(extraTags) == 0 {
+			extraTags = []string{"latest"}
+		}
+		args := []string{"repo", "publish-component", "meep", "1.2.3", "--skip-existing",
+			"-p", "windows/amd64=" + testutil.TestdataPath(t, "meepy-component", "windows"),
+			"-p", "linux/amd64=" + testutil.TestdataPath(t, "meepy-component", "unix"),
+			"-p", "darwin/amd64=" + testutil.TestdataPath(t, "meepy-component", "unix"),
+			"-p", "darwin/arm64=" + testutil.TestdataPath(t, "meepy-component", "unix"),
+		}
+		for _, tag := range extraTags {
+			args = append(args, []string{"--extra-tags", tag}...)
+		}
+		cmd.SetArgs(appendRegistryArgsFromEnv(args))
+		require.NoError(t, cmd.Execute())
+	})
+
 	t.Run("publish assistant", func(t *testing.T) {
 		cmd := createStdTestRootCmd(t)
 		args := []string{"repo", "publish-dpm", "4.5.6",

--- a/pkg/publish/publish.go
+++ b/pkg/publish/publish.go
@@ -44,6 +44,7 @@ type Config struct {
 	Registry     string
 	AuthFilePath string
 	Insecure     bool
+	SkipExisting bool
 }
 
 func (config *Config) RequiredAnnotations() ociconsts.DescriptorAnnotations {
@@ -111,7 +112,7 @@ func (p *Publisher) Publish(ctx context.Context) (err error) {
 		return v.String()
 	}), p.config.Version.String())
 
-	if alreadyExists {
+	if alreadyExists && !p.config.SkipExisting {
 		p.printer.Println("skipped pushing because component's index already exists in remote")
 	} else {
 		var descriptors []v1.Descriptor

--- a/pkg/publishcmd/publishcmd.go
+++ b/pkg/publishcmd/publishcmd.go
@@ -20,6 +20,7 @@ type PublishCmd struct {
 	Insecure     bool
 	Registry     string
 	RegistryAuth string
+	SkipExisting bool
 }
 
 func (c *PublishCmd) ParsePlatforms() (map[simpleplatform.Platform]string, error) {


### PR DESCRIPTION
Introduce a `--skip-existing` flag on the `repo publish-components` cmd to allow for components to be skipped over if they already exist in the registry