### PR TITLE
do not try to auto-commit on main, release line or tags

### DIFF
--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -48,10 +48,9 @@ jobs:
           fi
         shell: bash -euo pipefail -c "source nix.source && exec bash {0}"
       - name: Commit and push changes
-        if: github.ref_type == 'branch' 
+        if: github.ref_type == 'branch'
             && github.ref != 'refs/heads/main'
             && ! startsWith(github.ref, 'refs/heads/release-line')
-            && ! startsWith(github.ref, 'refs/tags/')
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Pull request overview

Updates the Black Duck workflow to avoid auto-committing generated `NOTICES` changes on protected refs (main/release lines/tags), reducing the risk of unintended writes from CI.

**Changes:**
- Gate the “Commit and push changes” step so it won’t run on `main`.
- Add an additional guard to skip `release-line*` refs (and tags).