### PR TITLE
include missing components when failing due to disabled auto-install

### DIFF
--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -290,15 +290,21 @@ func (a *Assembler) collectAssistant(ctx context.Context, assistant *sdkmanifest
 
 // component name -> *ResolvedComponent
 func (a *Assembler) collectComponents(ctx context.Context, assemblyManifest *sdkmanifest.SdkManifest) (result map[string]*ResolvedComponent, err error) {
+	var errs []error
+
 	result = make(map[string]*ResolvedComponent)
 	for _, comp := range assemblyManifest.Spec.Components {
 		resolved, err := a.collectComponent(ctx, assemblyManifest.AbsolutePath, comp)
 		if err != nil {
-			return nil, err
+			errs = append(errs, err)
+			continue
 		}
 		result[comp.Name] = resolved
 	}
 
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -350,7 +356,7 @@ func (a *Assembler) handleOCI(ctx context.Context, comp *sdkmanifest.Component) 
 			// As auto-installation of SDKs is disabled by default, so is pulling overridden remote components, as both SDKs and remote overrides
 			// are using the same AutoInstall config variable...
 			// so currently the only way the assistant to have the assistant pull remote overrides is to have the user enable auto-install
-			return "", fmt.Errorf("sdk component is missing and won't be downloaded because auto-install is disabled")
+			return "", fmt.Errorf("sdk component %q is missing and won't be downloaded because auto-install is disabled", comp.String())
 		}
 		platform := simpleplatform.CurrentPlatform()
 		if a.overridePlatform != nil {

--- a/pkg/sdkmanifest/spec.go
+++ b/pkg/sdkmanifest/spec.go
@@ -68,6 +68,18 @@ type Component struct {
 	LocalPath *string `yaml:"local-path,omitempty"`
 }
 
+// String returns representation meant for humans
+func (c *Component) String() string {
+	if c.Version != nil {
+		return fmt.Sprintf("%s:%s", c.Name, c.Version.Value().String())
+	} else if c.ImageTag != nil {
+		return fmt.Sprintf("%s:%s", c.Name, *c.ImageTag)
+	} else if c.LocalPath != nil {
+		return fmt.Sprintf("%s@%s", c.Name, *c.LocalPath)
+	}
+	return c.Name
+}
+
 func (c *Component) UnmarshalYAML(bytes []byte) error {
 	type Alias Component
 	alias := Alias{}


### PR DESCRIPTION
closes #33 

```
~/dpm/main build
sdk component "foo:1.2.3" is missing and won't be downloaded because auto-install is disabled
sdk component "bar:5.123.2" is missing and won't be downloaded because auto-install is disabled
```