### PR TITLE
support dar dependency fields in daml.yaml

### DIFF
--- a/pkg/damlpackage/damlproject_test.go
+++ b/pkg/damlpackage/damlproject_test.go
@@ -1,0 +1,30 @@
+package damlpackage
+
+import (
+	"testing"
+
+	"daml.com/x/assistant/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDarDependencies(t *testing.T) {
+	t.Setenv("TEST_DPM_REGISTRY_PORT", "5000")
+	p, err := Read(testutil.TestdataPath(t, "daml-dependencies", "daml.yaml"))
+	require.NoError(t, err)
+
+	assert.Len(t, p.Dependencies, 5)
+	assert.True(t, p.ArtifactLocations["@digital-asset"].Default)
+	assert.False(t, p.ArtifactLocations["@my-location"].Default)
+
+	assert.Len(t, p.ResolvedDependencies, len(p.Dependencies))
+
+	assert.NotNil(t, p.ResolvedDependencies["foo:devnet"].Location)
+	assert.NotNil(t, p.ResolvedDependencies["@my-location/foo:4.5.6"].Location)
+	assert.Nil(t, p.ResolvedDependencies["oci://localhost:5000/some/dars/foo:1.2.3"].Location)
+
+	assert.Equal(t, p.ResolvedDependencies["foo:devnet"].FullUrl.String(), "oci://localhost:5000/more/official/dars/foo:devnet")
+	assert.Equal(t, p.ResolvedDependencies["oci://localhost:5000/some/dars/foo:1.2.3"].FullUrl.String(), "oci://localhost:5000/some/dars/foo:1.2.3")
+	assert.Equal(t, p.ResolvedDependencies["@my-location/foo:4.5.6"].FullUrl.String(), "oci://localhost:5000/some/dars/n/stuff/foo:4.5.6")
+
+}

--- a/pkg/damlpackage/locations.go
+++ b/pkg/damlpackage/locations.go
@@ -1,0 +1,109 @@
+package damlpackage
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+type ArtifactLocations map[string]*ArtifactLocation
+
+type ArtifactLocation struct {
+	Url     string `yaml:"url"`
+	Default bool   `yaml:"default"`
+	Auth    string `yaml:"auth"`
+}
+
+type ResolvedDependency struct {
+	// the fully-qualified URL for the artifact e.g. oci://example.com/foo/bar/baz:1.2.3
+	FullUrl *url.URL
+
+	// can be nil when the corresponding dependency is already fully qualified and doesn't rely on an artifact-location
+	Location *ArtifactLocation
+}
+
+var regex = regexp.MustCompile(`^(@[a-zA-Z0-9_-]+)/[^/]+$`)
+
+func (ls ArtifactLocations) GetDefaultLocation() (name string, location *ArtifactLocation, err error) {
+	for s, l := range ls {
+		if l.Default {
+			if name != "" {
+				return "", nil, fmt.Errorf("only one artifact location can be set as default")
+			}
+			name = s
+			location = l
+		}
+	}
+	return
+}
+
+func (p *DamlPackage) computeResolvedDependencies(defaultLocation *ArtifactLocation) (map[string]*ResolvedDependency, error) {
+	resolved := map[string]*ResolvedDependency{}
+
+	var errs []error
+
+	for _, d := range p.Dependencies {
+		if strings.HasPrefix(d, "oci://") {
+			u, err := url.Parse(d)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("couldn't parse dependency url %q: %w", d, err))
+				continue
+			}
+			resolved[d] = &ResolvedDependency{FullUrl: u}
+		} else if strings.HasPrefix(d, "@") {
+			parsed := regex.FindStringSubmatch(d)
+			if len(parsed) < 2 {
+				errs = append(errs, fmt.Errorf("error parsing dependency %q: Dependencies beginning with @ must be of the form '@<artifact-location>/<suffix>'", d))
+				continue
+			}
+			location, ok := p.ArtifactLocations[parsed[1]]
+			if !ok {
+				errs = append(errs, fmt.Errorf("dependency %q has no corresponding artifact location", d))
+				continue
+			}
+
+			if location.Url == "" {
+				errs = append(errs, fmt.Errorf("invalid artifact location %q. Must have a non-empty url", location.Url))
+				continue
+			}
+
+			rawUrl := strings.Replace(d, parsed[1], location.Url, 1)
+			u, err := url.Parse(rawUrl)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("couldn't parse full url %q for dependency %q: ", rawUrl, d))
+				continue
+			}
+			resolved[d] = &ResolvedDependency{
+				Location: location,
+				FullUrl:  u,
+			}
+		} else if strings.Contains(d, ":") {
+			if defaultLocation == nil {
+				errs = append(errs, fmt.Errorf("failed to resolve dependency's artifact location for %q: no default artifact location is specified", d))
+				continue
+			}
+
+			rawUrl := fmt.Sprintf("%s/%s", defaultLocation.Url, d)
+			u, err := url.Parse(rawUrl)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("couldn't parse full url %q for dependency %q: ", rawUrl, d))
+				continue
+			}
+			resolved[d] = &ResolvedDependency{
+				Location: defaultLocation,
+				FullUrl:  u,
+			}
+		} else {
+			// non-remote dependency
+			resolved[d] = nil
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	return resolved, nil
+}

--- a/pkg/testutil/testdata/daml-dependencies/daml.yaml
+++ b/pkg/testutil/testdata/daml-dependencies/daml.yaml
@@ -1,0 +1,13 @@
+dependencies:
+  - daml-script
+  - ./meep.dar
+  - foo:devnet
+  - oci://localhost:$TEST_DPM_REGISTRY_PORT/some/dars/foo:1.2.3
+  - "@my-location/foo:4.5.6"
+
+artifact-locations:
+  "@digital-asset":
+     default: true
+     url: oci://localhost:$TEST_DPM_REGISTRY_PORT/more/official/dars
+  "@my-location":
+      url: oci://localhost:$TEST_DPM_REGISTRY_PORT/some/dars/n/stuff


### PR DESCRIPTION
add support for `artifact-locations` and `dependencies` fields in `daml.yaml`.
Includes some basic validation, e.g. that urls parse and referenced locations (`@whatever`) exist, etc..