### PR TITLE
return dar's non-floaty version when pulling

### DIFF
--- a/pkg/darpuller/darpuller.go
+++ b/pkg/darpuller/darpuller.go
@@ -1,14 +1,19 @@
 package darpuller
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"path/filepath"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/damlpackage"
+	ociconsts "daml.com/x/assistant/pkg/oci"
 	"daml.com/x/assistant/pkg/ocicache"
+	"github.com/Masterminds/semver/v3"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
@@ -24,21 +29,21 @@ func New(config *assistantconfig.Config) *OciDarPuller {
 	}
 }
 
-func (a *OciDarPuller) PullDar(ctx context.Context, dar *damlpackage.ResolvedDependency) (*v1.Descriptor, string, error) {
+func (a *OciDarPuller) PullDar(ctx context.Context, dar *damlpackage.ResolvedDependency) (*v1.Descriptor, *semver.Version, string, error) {
 	repo, ref, err := dar.GetOciRepo()
 	if err != nil {
-		return nil, "", err
+		return nil, nil, "", err
 	}
 
 	src, err := ocicache.CachedTarget(repo, a.config.OciLayoutCache)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, "", err
 	}
 
 	destPath := a.getPath(dar.FullUrl.String())
 	dest, err := file.New(destPath)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, "", err
 	}
 	dest.PreservePermissions = true
 	// errors out if dest already exists
@@ -46,11 +51,29 @@ func (a *OciDarPuller) PullDar(ctx context.Context, dar *damlpackage.ResolvedDep
 
 	desc, err := oras.Copy(ctx, src, ref.Reference, dest, ref.Reference, oras.CopyOptions{})
 	if err != nil {
-		return nil, "", err
+		return nil, nil, "", err
+	}
+
+	// figure out the dar's non-floaty semver
+	annotations, err := getAnnotations(ctx, src, desc)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	v := cmp.Or(
+		annotations[v1.AnnotationVersion],
+		// fallback
+		annotations[ociconsts.DescriptorVersionAnnotation],
+	)
+	if v == "" {
+		return nil, nil, "", fmt.Errorf("missing version annotation in image manifest")
+	}
+	ver, err := semver.StrictNewVersion(v)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("version annotation %q in image manifest isn't a strict semver: %w", v, err)
 	}
 
 	// TODO validate the pulled DAR is actually a DAR (?)
-	return &desc, destPath, err
+	return &desc, ver, destPath, err
 }
 
 func (a *OciDarPuller) getPath(rawUrl string) string {
@@ -61,4 +84,21 @@ func (a *OciDarPuller) getPath(rawUrl string) string {
 		"dars",
 		hex.EncodeToString(sha[:]),
 	)
+}
+
+func getAnnotations(ctx context.Context, repo oras.ReadOnlyTarget, desc v1.Descriptor) (map[string]string, error) {
+	rc, err := repo.Fetch(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+
+	// extract just the annotations
+	manifest := struct {
+		Annotations map[string]string `json:"annotations"`
+	}{}
+	if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+		return nil, err
+	}
+	return manifest.Annotations, nil
 }

--- a/pkg/darpuller/darpuller_test.go
+++ b/pkg/darpuller/darpuller_test.go
@@ -22,15 +22,15 @@ func TestOciDarPuller(t *testing.T) {
 	registry := httptest.NewTLSServer(registry.New())
 	defer registry.Close()
 
-	tag := "1.2.3"
+	version := "1.2.3"
 
 	// TODO: using a PushComponent() for lack of a PushDar() for now
-	testutil.PushComponent(t, ctx, registry, "meep", tag, testutil.TestdataPath(t, "some-dar"))
+	testutil.PushComponent(t, ctx, registry, "meep", version, testutil.TestdataPath(t, "some-dar"), "latest")
 
 	u, err := url.Parse(fmt.Sprintf("oci://%s/%s:%s",
 		strings.TrimPrefix(registry.URL, "https://"),
 		"components/meep",
-		tag,
+		"latest",
 	))
 	if err != nil {
 		require.NoError(t, err)
@@ -43,9 +43,11 @@ func TestOciDarPuller(t *testing.T) {
 		},
 	}
 
-	_, destPath, err := fake(t).PullDar(ctx, dar)
+	descriptor, v, destPath, err := fake(t).PullDar(ctx, dar)
 	require.NoError(t, err)
 	assert.NotEmpty(t, destPath)
+	assert.NotEmpty(t, descriptor.Digest)
+	assert.Equal(t, version, v.String())
 }
 
 func fake(t *testing.T) *OciDarPuller {

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -40,7 +40,7 @@ func TestdataPath(t *testing.T, path ...string) string {
 	return filepath.Join(p...)
 }
 
-func PushComponent(t *testing.T, ctx context.Context, registry *httptest.Server, componentName, tag, pathToComponent string) {
+func PushComponent(t *testing.T, ctx context.Context, registry *httptest.Server, componentName, tag, pathToComponent string, extraTags ...string) {
 	r := getRemote(registry)
 	v, err := semver.NewVersion(tag)
 	require.NoError(t, err)
@@ -70,6 +70,11 @@ func PushComponent(t *testing.T, ctx context.Context, registry *httptest.Server,
 	}
 	_, err = ociindex.PushIndex(ctx, r, indexOpts)
 	require.NoError(t, err)
+
+	if len(extraTags) > 0 {
+		err = ociindex.Tag(ctx, r, &ociconsts.ComponentArtifact{ComponentName: componentName}, v, extraTags)
+		require.NoError(t, err)
+	}
 }
 
 // PushAssembly pushes assembly manifest to OCI registry for all platforms


### PR DESCRIPTION
this will be necessary for lockfiles to include semvers in place of floaty tags