### PR TITLE
don't auto-generate lockfiles as part of resolution

### DIFF
--- a/pkg/resolver/deepresolver.go
+++ b/pkg/resolver/deepresolver.go
@@ -116,13 +116,6 @@ func (d *DeepResolver) resolvePackageAndDars(ctx context.Context, absPath string
 
 	lock, err := packagelock.ReadPackageLock(filepath.Join(absPath, assistantconfig.DpmLockFileName))
 	if errors.Is(err, os.ErrNotExist) {
-		lock, err = packagelock.New(d.config, packagelock.Regular).EnsureLockfile(ctx, absPath)
-		if err != nil {
-			return nil, err
-		}
-	}
-	_, err = packagelock.New(d.config, packagelock.CheckOnly).EnsureLockfile(ctx, absPath)
-	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Lockfiles will always require manual creation/updating, so i'm ripping out one instance where we auto-generate them.
The reason for this is that lockfile creation involves potential remote calls. This conflicts with the "should never auto-install things" requirement of dpm.