### PR TITLE
Revert "don't auto-generate lockfiles as part of resolution (#123)"

### DIFF
--- a/pkg/resolver/deepresolver.go
+++ b/pkg/resolver/deepresolver.go
@@ -116,6 +116,13 @@ func (d *DeepResolver) resolvePackageAndDars(ctx context.Context, absPath string
 
 	lock, err := packagelock.ReadPackageLock(filepath.Join(absPath, assistantconfig.DpmLockFileName))
 	if errors.Is(err, os.ErrNotExist) {
+		lock, err = packagelock.New(d.config, packagelock.Regular).EnsureLockfile(ctx, absPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	_, err = packagelock.New(d.config, packagelock.CheckOnly).EnsureLockfile(ctx, absPath)
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This reverts commit afa9d68a25931546c029357ef03b11955da1983e.