### PR TITLE
enhance resolve testing

### DIFF
--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -34,14 +34,14 @@ type MainSuite struct {
 	testutil.CommonSetupSuite
 }
 
-type ExpectedPackages struct {
-	ExpectedPackages   int
-	ExpectedDefaultSdk string
-	ExpectedComponents int
-	ExpectedImports    int
+type ExpectedResolution struct {
+	ExpectedPackages          int
+	ExpectedDefaultSdkVersion string
+	ExpectedComponents        int
+	ExpectedImports           int
 }
 
-var defaultExpectedPackages = ExpectedPackages{1, someSdkVersion, 1, 2}
+var defaultExpectedResolution = ExpectedResolution{1, someSdkVersion, 1, 2}
 
 const someSdkVersion = "0.0.1-whatever"
 const someOtherSdkVersion = "0.0.1-not-whatever"
@@ -55,7 +55,7 @@ func (suite *MainSuite) TestResolveMultiPackageRoot() {
 
 	installSdk(t, []string{someSdkVersion})
 	t.Setenv(assistantconfig.DamlProjectEnvVar, testutil.TestdataPath(t, "another-daml-package"))
-	testResolution(t, defaultExpectedPackages)
+	testResolution(t, defaultExpectedResolution)
 }
 
 func (suite *MainSuite) TestResolveMultiPackageSubdir() {
@@ -69,7 +69,7 @@ func (suite *MainSuite) TestResolveMultiPackageSubdir() {
 
 	// this will make daml.yaml in the CWD
 	require.NoError(t, os.Chdir(testutil.TestdataPath(t, "multi-package-with-subdir", "package")))
-	testResolution(t, defaultExpectedPackages)
+	testResolution(t, defaultExpectedResolution)
 }
 
 func (suite *MainSuite) TestResolveMultiPackageSdkVersion() {
@@ -80,7 +80,7 @@ func (suite *MainSuite) TestResolveMultiPackageSdkVersion() {
 	t.Run("1a: when in multi-package dir", func(t *testing.T) {
 		t.Chdir(testutil.TestdataPath(t, "multi-package-sdk-version"))
 
-		testResolution(t, ExpectedPackages{3, someSdkVersion, 1, 2})
+		testResolution(t, ExpectedResolution{3, someSdkVersion, 1, 2})
 		assertActiveSdkVersion(t, someSdkVersion)
 	})
 
@@ -89,7 +89,7 @@ func (suite *MainSuite) TestResolveMultiPackageSdkVersion() {
 
 		// test at level of single package
 		assertActiveSdkVersion(t, someSdkVersion)
-		testResolution(t, ExpectedPackages{3, someSdkVersion, 1, 2})
+		testResolution(t, ExpectedResolution{3, someSdkVersion, 1, 2})
 	})
 }
 
@@ -246,7 +246,7 @@ func (suite *MainSuite) TestResolveWithDpmSdkVersionEnvVar() {
 	})
 }
 
-func testResolution(t *testing.T, expectedPackages ExpectedPackages) {
+func testResolution(t *testing.T, expectedPackages ExpectedResolution) {
 	deepResolution := runResolveCommand(t)
 	assert.Len(t, deepResolution.Packages, expectedPackages.ExpectedPackages)
 	assert.Len(t, lo.Values(deepResolution.Packages)[0].Components, expectedPackages.ExpectedComponents)
@@ -269,8 +269,8 @@ func testResolution(t *testing.T, expectedPackages ExpectedPackages) {
 
 	t.Run("default sdk", func(t *testing.T) {
 		assert.Len(t, deepResolution.DefaultSDK, 1)
-		assert.Len(t, deepResolution.DefaultSDK[expectedPackages.ExpectedDefaultSdk].Components, 1)
-		assert.Len(t, deepResolution.DefaultSDK[expectedPackages.ExpectedDefaultSdk].Imports, 2)
+		assert.Len(t, deepResolution.DefaultSDK[expectedPackages.ExpectedDefaultSdkVersion].Components, 1)
+		assert.Len(t, deepResolution.DefaultSDK[expectedPackages.ExpectedDefaultSdkVersion].Imports, 2)
 		assert.True(t, true)
 	})
 

--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -34,6 +34,15 @@ type MainSuite struct {
 	testutil.CommonSetupSuite
 }
 
+type ExpectedPackages struct {
+	ExpectedPackages   int
+	ExpectedDefaultSdk string
+	ExpectedComponents int
+	ExpectedImports    int
+}
+
+var defaultExpectedPackages = ExpectedPackages{1, someSdkVersion, 1, 2}
+
 const someSdkVersion = "0.0.1-whatever"
 const someOtherSdkVersion = "0.0.1-not-whatever"
 
@@ -46,7 +55,7 @@ func (suite *MainSuite) TestResolveMultiPackageRoot() {
 
 	installSdk(t, []string{someSdkVersion})
 	t.Setenv(assistantconfig.DamlProjectEnvVar, testutil.TestdataPath(t, "another-daml-package"))
-	testResolution(t, 1, someSdkVersion)
+	testResolution(t, defaultExpectedPackages)
 }
 
 func (suite *MainSuite) TestResolveMultiPackageSubdir() {
@@ -60,7 +69,7 @@ func (suite *MainSuite) TestResolveMultiPackageSubdir() {
 
 	// this will make daml.yaml in the CWD
 	require.NoError(t, os.Chdir(testutil.TestdataPath(t, "multi-package-with-subdir", "package")))
-	testResolution(t, 1, someSdkVersion)
+	testResolution(t, defaultExpectedPackages)
 }
 
 func (suite *MainSuite) TestResolveMultiPackageSdkVersion() {
@@ -71,7 +80,7 @@ func (suite *MainSuite) TestResolveMultiPackageSdkVersion() {
 	t.Run("1a: when in multi-package dir", func(t *testing.T) {
 		t.Chdir(testutil.TestdataPath(t, "multi-package-sdk-version"))
 
-		testResolution(t, 3, someSdkVersion)
+		testResolution(t, ExpectedPackages{3, someSdkVersion, 1, 2})
 		assertActiveSdkVersion(t, someSdkVersion)
 	})
 
@@ -80,7 +89,7 @@ func (suite *MainSuite) TestResolveMultiPackageSdkVersion() {
 
 		// test at level of single package
 		assertActiveSdkVersion(t, someSdkVersion)
-		testResolution(t, 3, someSdkVersion)
+		testResolution(t, ExpectedPackages{3, someSdkVersion, 1, 2})
 	})
 }
 
@@ -237,14 +246,16 @@ func (suite *MainSuite) TestResolveWithDpmSdkVersionEnvVar() {
 	})
 }
 
-func testResolution(t *testing.T, expectedPackages int, expectedDefaultSdk string) {
+func testResolution(t *testing.T, expectedPackages ExpectedPackages) {
 	deepResolution := runResolveCommand(t)
-	assert.Len(t, deepResolution.Packages, expectedPackages)
-	assert.Len(t, lo.Values(deepResolution.Packages)[0].Components, 1)
-	assert.ElementsMatch(t,
-		lo.Keys(lo.Values(deepResolution.Packages)[0].ComponentsV2),
-		[]string{"meep"})
-	assert.Len(t, lo.Values(deepResolution.Packages)[0].Imports, 2)
+	assert.Len(t, deepResolution.Packages, expectedPackages.ExpectedPackages)
+	assert.Len(t, lo.Values(deepResolution.Packages)[0].Components, expectedPackages.ExpectedComponents)
+	if expectedPackages.ExpectedComponents > 0 {
+		assert.ElementsMatch(t,
+			lo.Keys(lo.Values(deepResolution.Packages)[0].ComponentsV2),
+			[]string{"meep"})
+	}
+	assert.Len(t, lo.Values(deepResolution.Packages)[0].Imports, expectedPackages.ExpectedImports)
 	assert.Equal(t, resolution.Kind, deepResolution.Kind)
 	assert.Equal(t, resolution.ApiVersion, deepResolution.APIVersion)
 
@@ -258,8 +269,8 @@ func testResolution(t *testing.T, expectedPackages int, expectedDefaultSdk strin
 
 	t.Run("default sdk", func(t *testing.T) {
 		assert.Len(t, deepResolution.DefaultSDK, 1)
-		assert.Len(t, deepResolution.DefaultSDK[expectedDefaultSdk].Components, 1)
-		assert.Len(t, deepResolution.DefaultSDK[expectedDefaultSdk].Imports, 2)
+		assert.Len(t, deepResolution.DefaultSDK[expectedPackages.ExpectedDefaultSdk].Components, 1)
+		assert.Len(t, deepResolution.DefaultSDK[expectedPackages.ExpectedDefaultSdk].Imports, 2)
 		assert.True(t, true)
 	})
 

--- a/cmd/dpm/cmd/lockfile_test.go
+++ b/cmd/dpm/cmd/lockfile_test.go
@@ -125,29 +125,22 @@ func (suite *MainSuite) TestLockfileSdkVersion() {
 
 	testActiveSdkVersionExhaustive(t, func(t *testing.T, tc SdkVersionTestCase, dirs TestCaseDirs) {
 		// TODO: Implement writing global sdk into lockfile and enforce test
-		if t.Name() == "TestSuite/TestLockfileSdkVersion/7_multi:null_pkg:some_wd:multi" {
+		if t.Name() == "TestSuite/TestLockfileSdkVersion/7_multi:null_pkg:some_wd:multi" ||
+			t.Name() == "TestSuite/TestLockfileSdkVersion/9_multi:null_pkg:null_wd:multi" ||
+			t.Name() == "TestSuite/TestLockfileSdkVersion/18_multi:null_pkg:null_wd:pkg" {
 			t.Skip()
 		}
 		cmd := createStdTestRootCmd(t, "update")
 		require.NoError(t, cmd.Execute())
 
-		if tc.WorkingDir != PackageWorkingDir {
+		if tc.WorkingDir != PackageWorkingDir { // multi package
 			multiLock, err := packagelock.ReadPackageLock(filepath.Join(dirs.MultiPackageDir, assistantconfig.DpmMultiPackageLockFileName))
 			require.NoError(t, err)
-			if tc.ExpectedVersion == "null" {
-				assert.Equal(t, multiLock.SdkVersion.Version, "")
-			} else {
-				assert.Equal(t, multiLock.SdkVersion.Version, tc.ExpectedVersion)
-			}
-		} else {
+			assert.Equal(t, tc.ExpectedVersion, multiLock.SdkVersion.Version)
+		} else { //single package
 			lock, err := packagelock.ReadPackageLock(filepath.Join(dirs.DamlPackageDir, assistantconfig.DpmLockFileName))
 			require.NoError(t, err)
-
-			if tc.ExpectedVersion == "null" {
-				assert.Equal(t, lock.SdkVersion.Version, "")
-			} else {
-				assert.Equal(t, lock.SdkVersion.Version, tc.ExpectedVersion)
-			}
+			assert.Equal(t, tc.ExpectedVersion, lock.SdkVersion.Version)
 		}
 	})
 }

--- a/cmd/dpm/cmd/sdkversion_test.go
+++ b/cmd/dpm/cmd/sdkversion_test.go
@@ -27,9 +27,12 @@ type SdkVersionTestCase struct {
 	MultiPackageSdkVersion, PackageSdkVersion string
 	WorkingDir                                WorkingDir
 	ExpectedVersion                           string
+	ExpectedPackages                          ExpectedPackages
 }
 
 const globalSdkVersion = "999.999.999"
+
+var expectedPackages = ExpectedPackages{1, globalSdkVersion, 1, 2}
 
 var sdkVersionTestCases = []SdkVersionTestCase{
 	{
@@ -38,6 +41,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             MultiPackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
+		ExpectedPackages:       expectedPackages,
 	},
 	{
 		Name:                   "2 multi:some pkg:other wd:multi",
@@ -45,6 +49,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someOtherSdkVersion,
 		WorkingDir:             MultiPackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
+		ExpectedPackages:       expectedPackages,
 	},
 	{
 		Name:                   "3 multi:some pkg:null wd:multi",
@@ -52,6 +57,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      "null",
 		WorkingDir:             MultiPackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
+		ExpectedPackages:       expectedPackages,
 	},
 	{
 		Name:                   "7 multi:null pkg:some wd:multi",
@@ -59,21 +65,23 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             MultiPackageWorkingDir,
 		ExpectedVersion:        globalSdkVersion,
+		ExpectedPackages:       expectedPackages,
 	},
-	// TODO figure out why this is returning different resolve results
-	//{
-	//	Name:                   "9 multi:null pkg:null wd:multi",
-	//	MultiPackageSdkVersion: "null",
-	//	PackageSdkVersion:      "null",
-	//	WorkingDir:             MultiPackageWorkingDir,
-	//	ExpectedVersion:        globalSdkVersion,
-	//},
+	{
+		Name:                   "9 multi:null pkg:null wd:multi",
+		MultiPackageSdkVersion: "null",
+		PackageSdkVersion:      "null",
+		WorkingDir:             MultiPackageWorkingDir,
+		ExpectedVersion:        globalSdkVersion,
+		ExpectedPackages:       ExpectedPackages{1, globalSdkVersion, 0, 0},
+	},
 	{
 		Name:                   "10 multi:some pkg:some wd:pkg",
 		MultiPackageSdkVersion: someSdkVersion,
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
+		ExpectedPackages:       expectedPackages,
 	},
 	{
 		Name:                   "11 multi:some pkg:other wd:pkg",
@@ -81,6 +89,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someOtherSdkVersion,
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        someOtherSdkVersion,
+		ExpectedPackages:       expectedPackages,
 	},
 	{
 		Name:                   "12 multi:some pkg:null wd:pkg",
@@ -88,6 +97,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      "null",
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
+		ExpectedPackages:       expectedPackages,
 	},
 	{
 		Name:                   "13 multi:other pkg:some wd:pkg",
@@ -95,6 +105,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
+		ExpectedPackages:       expectedPackages,
 	},
 	{
 		Name:                   "16 multi:null pkg:some wd:pkg",
@@ -102,6 +113,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
+		ExpectedPackages:       expectedPackages,
 	},
 	{
 		Name:                   "18 multi:null pkg:null wd:pkg",
@@ -109,6 +121,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      "null",
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        "null",
+		ExpectedPackages:       expectedPackages,
 	},
 }
 
@@ -171,7 +184,7 @@ packages:
 			} else {
 				t.Run("assert active sdk version", func(t *testing.T) {
 					assertActiveSdkVersion(t, tc.ExpectedVersion)
-					testResolution(t, 1, globalSdkVersion)
+					testResolution(t, tc.ExpectedPackages)
 				})
 			}
 		})

--- a/cmd/dpm/cmd/sdkversion_test.go
+++ b/cmd/dpm/cmd/sdkversion_test.go
@@ -32,7 +32,11 @@ type SdkVersionTestCase struct {
 
 const globalSdkVersion = "999.999.999"
 
-var expectedResolution = ExpectedResolution{1, globalSdkVersion, 1, 2}
+var expectedResolution = ExpectedResolution{
+	1,
+	globalSdkVersion,
+	1,
+	2}
 
 var sdkVersionTestCases = []SdkVersionTestCase{
 	{
@@ -73,7 +77,23 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      "null",
 		WorkingDir:             MultiPackageWorkingDir,
 		ExpectedVersion:        globalSdkVersion,
-		ExpectedResolution:     ExpectedResolution{1, globalSdkVersion, 0, 0},
+		ExpectedResolution: ExpectedResolution{
+			1,
+			globalSdkVersion,
+			0,
+			0},
+	},
+	{
+		Name:                   "18 multi:null pkg:null wd:pkg",
+		MultiPackageSdkVersion: "null",
+		PackageSdkVersion:      "null",
+		WorkingDir:             PackageWorkingDir,
+		ExpectedVersion:        "null",
+		ExpectedResolution: ExpectedResolution{
+			1,
+			globalSdkVersion,
+			0,
+			0},
 	},
 	{
 		Name:                   "10 multi:some pkg:some wd:pkg",
@@ -113,14 +133,6 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
-		ExpectedResolution:     expectedResolution,
-	},
-	{
-		Name:                   "18 multi:null pkg:null wd:pkg",
-		MultiPackageSdkVersion: "null",
-		PackageSdkVersion:      "null",
-		WorkingDir:             PackageWorkingDir,
-		ExpectedVersion:        "null",
 		ExpectedResolution:     expectedResolution,
 	},
 }
@@ -176,9 +188,9 @@ packages:
 			hook(t, tc, dirs)
 
 			if tc.ExpectedVersion == "null" {
-
 				t.Run("assert no active sdk version", func(t *testing.T) {
 					assertNoActiveSdkVersion(t)
+					testResolution(t, tc.ExpectedResolution)
 				})
 
 			} else {

--- a/cmd/dpm/cmd/sdkversion_test.go
+++ b/cmd/dpm/cmd/sdkversion_test.go
@@ -27,12 +27,12 @@ type SdkVersionTestCase struct {
 	MultiPackageSdkVersion, PackageSdkVersion string
 	WorkingDir                                WorkingDir
 	ExpectedVersion                           string
-	ExpectedPackages                          ExpectedResolution
+	ExpectedResolution                        ExpectedResolution
 }
 
 const globalSdkVersion = "999.999.999"
 
-var expectedPackages = ExpectedResolution{1, globalSdkVersion, 1, 2}
+var expectedResolution = ExpectedResolution{1, globalSdkVersion, 1, 2}
 
 var sdkVersionTestCases = []SdkVersionTestCase{
 	{
@@ -41,7 +41,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             MultiPackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
-		ExpectedPackages:       expectedPackages,
+		ExpectedResolution:     expectedResolution,
 	},
 	{
 		Name:                   "2 multi:some pkg:other wd:multi",
@@ -49,7 +49,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someOtherSdkVersion,
 		WorkingDir:             MultiPackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
-		ExpectedPackages:       expectedPackages,
+		ExpectedResolution:     expectedResolution,
 	},
 	{
 		Name:                   "3 multi:some pkg:null wd:multi",
@@ -57,7 +57,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      "null",
 		WorkingDir:             MultiPackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
-		ExpectedPackages:       expectedPackages,
+		ExpectedResolution:     expectedResolution,
 	},
 	{
 		Name:                   "7 multi:null pkg:some wd:multi",
@@ -65,7 +65,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             MultiPackageWorkingDir,
 		ExpectedVersion:        globalSdkVersion,
-		ExpectedPackages:       expectedPackages,
+		ExpectedResolution:     expectedResolution,
 	},
 	{
 		Name:                   "9 multi:null pkg:null wd:multi",
@@ -73,7 +73,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      "null",
 		WorkingDir:             MultiPackageWorkingDir,
 		ExpectedVersion:        globalSdkVersion,
-		ExpectedPackages:       ExpectedResolution{1, globalSdkVersion, 0, 0},
+		ExpectedResolution:     ExpectedResolution{1, globalSdkVersion, 0, 0},
 	},
 	{
 		Name:                   "10 multi:some pkg:some wd:pkg",
@@ -81,7 +81,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
-		ExpectedPackages:       expectedPackages,
+		ExpectedResolution:     expectedResolution,
 	},
 	{
 		Name:                   "11 multi:some pkg:other wd:pkg",
@@ -89,7 +89,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someOtherSdkVersion,
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        someOtherSdkVersion,
-		ExpectedPackages:       expectedPackages,
+		ExpectedResolution:     expectedResolution,
 	},
 	{
 		Name:                   "12 multi:some pkg:null wd:pkg",
@@ -97,7 +97,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      "null",
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
-		ExpectedPackages:       expectedPackages,
+		ExpectedResolution:     expectedResolution,
 	},
 	{
 		Name:                   "13 multi:other pkg:some wd:pkg",
@@ -105,7 +105,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
-		ExpectedPackages:       expectedPackages,
+		ExpectedResolution:     expectedResolution,
 	},
 	{
 		Name:                   "16 multi:null pkg:some wd:pkg",
@@ -113,7 +113,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
-		ExpectedPackages:       expectedPackages,
+		ExpectedResolution:     expectedResolution,
 	},
 	{
 		Name:                   "18 multi:null pkg:null wd:pkg",
@@ -121,7 +121,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      "null",
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        "null",
-		ExpectedPackages:       expectedPackages,
+		ExpectedResolution:     expectedResolution,
 	},
 }
 
@@ -184,7 +184,7 @@ packages:
 			} else {
 				t.Run("assert active sdk version", func(t *testing.T) {
 					assertActiveSdkVersion(t, tc.ExpectedVersion)
-					testResolution(t, tc.ExpectedPackages)
+					testResolution(t, tc.ExpectedResolution)
 				})
 			}
 		})

--- a/cmd/dpm/cmd/sdkversion_test.go
+++ b/cmd/dpm/cmd/sdkversion_test.go
@@ -27,12 +27,12 @@ type SdkVersionTestCase struct {
 	MultiPackageSdkVersion, PackageSdkVersion string
 	WorkingDir                                WorkingDir
 	ExpectedVersion                           string
-	ExpectedPackages                          ExpectedPackages
+	ExpectedPackages                          ExpectedResolution
 }
 
 const globalSdkVersion = "999.999.999"
 
-var expectedPackages = ExpectedPackages{1, globalSdkVersion, 1, 2}
+var expectedPackages = ExpectedResolution{1, globalSdkVersion, 1, 2}
 
 var sdkVersionTestCases = []SdkVersionTestCase{
 	{
@@ -73,7 +73,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      "null",
 		WorkingDir:             MultiPackageWorkingDir,
 		ExpectedVersion:        globalSdkVersion,
-		ExpectedPackages:       ExpectedPackages{1, globalSdkVersion, 0, 0},
+		ExpectedPackages:       ExpectedResolution{1, globalSdkVersion, 0, 0},
 	},
 	{
 		Name:                   "10 multi:some pkg:some wd:pkg",


### PR DESCRIPTION
• uncomment the resolve test in matrix of sdk tests that doesn't return any packages -- enhance testResolution to be able to handle different expected scenarios
• skip the lockfile tests that aren't yet implemented