### PR TITLE
more specific sdk-version component assertions

### DIFF
--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -18,9 +18,11 @@ import (
 	"daml.com/x/assistant/pkg/builtincommand"
 	ociconsts "daml.com/x/assistant/pkg/oci"
 	"daml.com/x/assistant/pkg/resolution"
+	"daml.com/x/assistant/pkg/schema"
 	"daml.com/x/assistant/pkg/sdkmanifest"
 	"daml.com/x/assistant/pkg/testutil"
 	"daml.com/x/assistant/pkg/utils"
+	"github.com/Masterminds/semver/v3"
 	"github.com/goccy/go-yaml"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
@@ -37,11 +39,9 @@ type MainSuite struct {
 type ExpectedResolution struct {
 	ExpectedPackages          int
 	ExpectedDefaultSdkVersion string
-	ExpectedComponents        int
+	ExpectedComponents        []string
 	ExpectedImports           int
 }
-
-var defaultExpectedResolution = ExpectedResolution{1, someSdkVersion, 1, 2}
 
 const someSdkVersion = "0.0.1-whatever"
 const someOtherSdkVersion = "0.0.1-not-whatever"
@@ -55,7 +55,7 @@ func (suite *MainSuite) TestResolveMultiPackageRoot() {
 
 	installSdk(t, []string{someSdkVersion})
 	t.Setenv(assistantconfig.DamlProjectEnvVar, testutil.TestdataPath(t, "another-daml-package"))
-	testResolution(t, defaultExpectedResolution)
+	testResolution(t, ExpectedResolution{1, someSdkVersion, []string{someSdkComponent}, 2})
 }
 
 func (suite *MainSuite) TestResolveMultiPackageSubdir() {
@@ -69,28 +69,7 @@ func (suite *MainSuite) TestResolveMultiPackageSubdir() {
 
 	// this will make daml.yaml in the CWD
 	require.NoError(t, os.Chdir(testutil.TestdataPath(t, "multi-package-with-subdir", "package")))
-	testResolution(t, defaultExpectedResolution)
-}
-
-func (suite *MainSuite) TestResolveMultiPackageSdkVersion() {
-	t := suite.T()
-
-	installSdk(t, []string{someSdkVersion})
-
-	t.Run("1a: when in multi-package dir", func(t *testing.T) {
-		t.Chdir(testutil.TestdataPath(t, "multi-package-sdk-version"))
-
-		testResolution(t, ExpectedResolution{3, someSdkVersion, 1, 2})
-		assertActiveSdkVersion(t, someSdkVersion)
-	})
-
-	t.Run("1b: when in sub package dir", func(t *testing.T) {
-		t.Chdir(testutil.TestdataPath(t, "multi-package-sdk-version", "main"))
-
-		// test at level of single package
-		assertActiveSdkVersion(t, someSdkVersion)
-		testResolution(t, ExpectedResolution{3, someSdkVersion, 1, 2})
-	})
+	testResolution(t, ExpectedResolution{1, someSdkVersion, []string{someSdkComponent}, 2})
 }
 
 func (suite *MainSuite) TestResolveMultiPackageSdkVersionWithOverrides() {
@@ -249,15 +228,11 @@ func (suite *MainSuite) TestResolveWithDpmSdkVersionEnvVar() {
 func testResolution(t *testing.T, expectedPackages ExpectedResolution) {
 	deepResolution := runResolveCommand(t)
 	assert.Len(t, deepResolution.Packages, expectedPackages.ExpectedPackages)
-	assert.Len(t, lo.Values(deepResolution.Packages)[0].Components, expectedPackages.ExpectedComponents)
-	if expectedPackages.ExpectedComponents > 0 {
-		assert.ElementsMatch(t,
-			lo.Keys(lo.Values(deepResolution.Packages)[0].ComponentsV2),
-			[]string{"meep"})
-	}
+	assert.Len(t, lo.Values(deepResolution.Packages)[0].Components, len(expectedPackages.ExpectedComponents))
 	assert.Len(t, lo.Values(deepResolution.Packages)[0].Imports, expectedPackages.ExpectedImports)
 	assert.Equal(t, resolution.Kind, deepResolution.Kind)
 	assert.Equal(t, resolution.ApiVersion, deepResolution.APIVersion)
+	assert.ElementsMatch(t, lo.Keys(lo.Values(deepResolution.Packages)[0].ComponentsV2), expectedPackages.ExpectedComponents)
 
 	t.Run("correct package paths", func(t *testing.T) {
 		for pkgPath := range deepResolution.Packages {
@@ -551,6 +526,73 @@ func installSdk(t *testing.T, versions []string) {
 			assertSdkVersion(t, version)
 		})
 	}
+
+	// verify
+	testMeepyComponent(t)
+	t.Run("link assistant", verifyLink)
+}
+
+func installSdkForComponent(t *testing.T, sdkVersion, componentName, componentVersion string) {
+	ctx := testutil.Context(t)
+	_, reg := testutil.StartRegistry(t)
+
+	assert.NotEmpty(t, os.Getenv(assistantconfig.DpmHomeEnvVar), "must set DPM_HOME to use installSdkForComponent")
+
+	componentSemVer, err := semver.NewVersion(componentVersion)
+	require.NoError(t, err)
+
+	sdkSemVer, err := semver.NewVersion(sdkVersion)
+	require.NoError(t, err)
+
+	assistantVersion, err := semver.NewVersion("4.5.6")
+	require.NoError(t, err)
+
+	// create an SdkManifest and push it
+	edition := sdkmanifest.OpenSource
+	sdkManifest := sdkmanifest.SdkManifest{
+		ManifestMeta: schema.ManifestMeta{
+			APIVersion: sdkmanifest.SdkManifestAPIVersion,
+			Kind:       sdkmanifest.SdkManifestKind,
+		},
+		Spec: &sdkmanifest.Spec{
+			Components: map[string]*sdkmanifest.Component{
+				componentName: &sdkmanifest.Component{
+					Name:    componentName,
+					Version: sdkmanifest.AssemblySemVer(componentSemVer),
+				},
+			},
+			Assistant: &sdkmanifest.Component{
+				Name:    sdkmanifest.AssistantName,
+				Version: sdkmanifest.AssemblySemVer(assistantVersion),
+			},
+			Version: sdkmanifest.AssemblySemVer(sdkSemVer),
+			Edition: &edition,
+		},
+	}
+	sdkManifestBytes, err := yaml.Marshal(sdkManifest)
+	require.NoError(t, err)
+	sdkManifestPath := filepath.Join(t.TempDir(), "sdk.yaml")
+	require.NoError(t, os.WriteFile(sdkManifestPath, sdkManifestBytes, 0666))
+	testutil.PushAssembly(t, ctx, edition, reg, sdkVersion, sdkManifestPath)
+
+	// push assistant, and component
+	testutil.PushComponent(t, ctx, reg, componentName, componentVersion, testutil.TestdataPath(t, "meepy-component", testutil.OS))
+	testutil.PushComponent(t, ctx, reg, sdkmanifest.AssistantName, "4.5.6", testutil.TestdataPath(t, "assistant-binary", testutil.OS))
+
+	t.Run("install_"+sdkVersion, func(t *testing.T) {
+		cmd, r, w := createTestRootCmd(t, "install", sdkVersion)
+
+		require.NoError(t, cmd.Execute())
+		assert.NoError(t, w.Close())
+
+		output, err := io.ReadAll(r)
+		require.NoError(t, err)
+
+		assert.Contains(t, string(output), "Successfully installed SDK "+sdkVersion)
+
+		// verify installation for this version
+		assertSdkVersion(t, sdkVersion)
+	})
 
 	// verify
 	testMeepyComponent(t)

--- a/cmd/dpm/cmd/sdkversion_test.go
+++ b/cmd/dpm/cmd/sdkversion_test.go
@@ -36,12 +36,19 @@ type SdkVersionTestCase struct {
 	ExpectedResolution                        ExpectedResolution
 }
 
-const globalSdkVersion = "999.999.999"
+const (
+	globalSdkVersion = "999.999.999"
+
+	globalSdkComponent    = "bleep" // contained in the globalSdkVersion sdk
+	someSdkComponent      = "meep"  // contained in the someSdkVersion sdk
+	someOtherSdkComponent = "sheep" // contained in the someOtherSdkVersion sdk
+
+)
 
 var expectedResolution = ExpectedResolution{
 	1,
 	globalSdkVersion,
-	1,
+	[]string{someSdkComponent},
 	2}
 
 var sdkVersionTestCases = []SdkVersionTestCase{
@@ -59,7 +66,11 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someOtherSdkVersion,
 		WorkingDir:             MultiPackageWorkingDir,
 		ExpectedVersion:        someSdkVersion,
-		ExpectedResolution:     expectedResolution,
+		ExpectedResolution: ExpectedResolution{
+			1,
+			globalSdkVersion,
+			[]string{someOtherSdkComponent},
+			2},
 	},
 	{
 		Name:                   "3 multi:some pkg:null wd:multi",
@@ -86,7 +97,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		ExpectedResolution: ExpectedResolution{
 			1,
 			globalSdkVersion,
-			0,
+			[]string{},
 			0},
 	},
 	{
@@ -98,7 +109,7 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		ExpectedResolution: ExpectedResolution{
 			1,
 			globalSdkVersion,
-			0,
+			[]string{},
 			0},
 	},
 	{
@@ -115,7 +126,11 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		PackageSdkVersion:      someOtherSdkVersion,
 		WorkingDir:             PackageWorkingDir,
 		ExpectedVersion:        someOtherSdkVersion,
-		ExpectedResolution:     expectedResolution,
+		ExpectedResolution: ExpectedResolution{
+			1,
+			globalSdkVersion,
+			[]string{someOtherSdkComponent},
+			2},
 	},
 	{
 		Name:                   "12 multi:some pkg:null wd:pkg",
@@ -152,8 +167,9 @@ func testActiveSdkVersionExhaustive(t *testing.T, hook func(t *testing.T, testCa
 	tmpDamlHome := t.TempDir()
 	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDamlHome)
 
-	sdkVersions := []string{someSdkVersion, someOtherSdkVersion, globalSdkVersion}
-	installSdk(t, sdkVersions)
+	installSdkForComponent(t, globalSdkVersion, globalSdkComponent, "999.999.999")
+	installSdkForComponent(t, someSdkVersion, someSdkComponent, "1.2.3")
+	installSdkForComponent(t, someOtherSdkVersion, someOtherSdkComponent, "4.5.6")
 
 	setupTestCase := func(tc SdkVersionTestCase) (dirs TestCaseDirs) {
 		tmpDir := t.TempDir()
@@ -240,7 +256,7 @@ packages:
 					// to run (i.e. in the --help) so that we can obtain the injected env var(s).
 					// To test this, we'd need to add an override-component, so that we have at least 1 command
 				} else {
-					assert.True(t, wasCalled.Load(), tc.ExpectedResolution)
+					assert.True(t, wasCalled.Load())
 				}
 			})
 


### PR DESCRIPTION
address another blindspot of the current "sdk-version overriding" feature's tests.
These tests verified the sdk-version, but not that the components used at the end of the day really do come from the that determined sdk-version