### PR TITLE
add `components`  field to daml.yaml and multi-package.yaml

### DIFF
--- a/pkg/assembler/assemblyplan/assemblyplan.go
+++ b/pkg/assembler/assemblyplan/assemblyplan.go
@@ -105,11 +105,11 @@ func NewShallow(ctx context.Context, config *assistantconfig.Config, a *assemble
 			plan.Base = *base
 		}
 
-		if damlPackage.OverrideComponents != nil {
+		if damlPackage.Components != nil {
 			plan.DamlPackage = &sdkmanifest.SdkManifest{
 				AbsolutePath: damlPackagePath,
 				Spec: &sdkmanifest.Spec{
-					Components: damlPackage.OverrideComponents,
+					Components: damlPackage.Components,
 				},
 			}
 		}
@@ -173,7 +173,7 @@ func configureMultiPackage(plan *AssemblyPlan) error {
 	plan.MultiPackage = &sdkmanifest.SdkManifest{
 		AbsolutePath: multiPackagePath,
 		Spec: &sdkmanifest.Spec{
-			Components: multiPackage.OverrideComponents,
+			Components: multiPackage.Components,
 		},
 	}
 	return nil

--- a/pkg/damlpackage/damlproject.go
+++ b/pkg/damlpackage/damlproject.go
@@ -5,6 +5,7 @@ package damlpackage
 
 import (
 	"fmt"
+	"maps"
 	"os"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
@@ -13,11 +14,15 @@ import (
 )
 
 type DamlPackage struct {
-	SdkVersion           string                            `yaml:"sdk-version"`
-	OverrideComponents   map[string]*sdkmanifest.Component `yaml:"override-components"`
-	Dependencies         []string                          `yaml:"dependencies"`
-	ArtifactLocations    ArtifactLocations                 `yaml:"artifact-locations"`
-	ResolvedDependencies map[string]*ResolvedDependency    `yaml:"-"`
+	SdkVersion string `yaml:"sdk-version"`
+
+	Components map[string]*sdkmanifest.Component `yaml:"components"`
+	// deprecated in favor of Components
+	DeprecatedOverrideComponents map[string]*sdkmanifest.Component `yaml:"override-components"`
+
+	Dependencies         []string                       `yaml:"dependencies"`
+	ArtifactLocations    ArtifactLocations              `yaml:"artifact-locations"`
+	ResolvedDependencies map[string]*ResolvedDependency `yaml:"-"`
 }
 
 func Read(filePath string) (*DamlPackage, error) {
@@ -38,10 +43,27 @@ func ReadFromContents(contents []byte) (*DamlPackage, error) {
 	if err := yaml.UnmarshalWithOptions(expanded, &obj); err != nil {
 		return nil, err
 	}
-	if obj.OverrideComponents != nil {
-		for name, comp := range obj.OverrideComponents {
+
+	if obj.Components != nil {
+		for name, comp := range obj.Components {
 			comp.Name = name
 		}
+	}
+
+	if obj.DeprecatedOverrideComponents != nil {
+		for name, comp := range obj.DeprecatedOverrideComponents {
+			comp.Name = name
+		}
+
+		if obj.Components != nil {
+			return nil, fmt.Errorf("fields 'components' and 'override-components' cannot be both simultaneously specified. Prefer 'components' as 'override-components' is deprecated")
+		}
+
+		obj.Components = make(map[string]*sdkmanifest.Component)
+		maps.Copy(obj.Components, obj.DeprecatedOverrideComponents)
+
+		// zero it out to make sure we really aren't relying on it past this point
+		obj.DeprecatedOverrideComponents = nil
 	}
 
 	if assistantconfig.DpmLockfileEnabled() {

--- a/pkg/damlpackage/damlproject_test.go
+++ b/pkg/damlpackage/damlproject_test.go
@@ -1,6 +1,8 @@
 package damlpackage
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
@@ -28,5 +30,41 @@ func TestDarDependencies(t *testing.T) {
 	assert.Equal(t, p.ResolvedDependencies["foo:devnet"].FullUrl.String(), "oci://localhost:5000/more/official/dars/foo:devnet")
 	assert.Equal(t, p.ResolvedDependencies["oci://localhost:5000/some/dars/foo:1.2.3"].FullUrl.String(), "oci://localhost:5000/some/dars/foo:1.2.3")
 	assert.Equal(t, p.ResolvedDependencies["@my-location/foo:4.5.6"].FullUrl.String(), "oci://localhost:5000/some/dars/n/stuff/foo:4.5.6")
+
+}
+
+func makeDamlYaml(fields ...string) []byte {
+	s := fmt.Sprintf("sdk-version: 3.4.5\n%s", strings.Join(fields, "\n"))
+	return []byte(s)
+}
+
+func TestComponentFields(t *testing.T) {
+	componentsField := `
+components:
+  foo:
+    version: 4.5.6
+`
+	overrideComponentsField := `
+override-components:
+  damlc:
+    version: 1.2.3
+`
+
+	t.Run("cannot use both fields together", func(t *testing.T) {
+		_, err := ReadFromContents(makeDamlYaml(componentsField, overrideComponentsField))
+		require.Error(t, err)
+	})
+
+	t.Run("populates components fields", func(t *testing.T) {
+		p, err := ReadFromContents(makeDamlYaml(componentsField))
+		require.NoError(t, err)
+		assert.Contains(t, p.Components, "foo")
+	})
+
+	t.Run("populates components fields from override-components", func(t *testing.T) {
+		p, err := ReadFromContents(makeDamlYaml(overrideComponentsField))
+		require.NoError(t, err)
+		assert.Contains(t, p.Components, "damlc")
+	})
 
 }

--- a/pkg/multipackage/multipackage.go
+++ b/pkg/multipackage/multipackage.go
@@ -4,6 +4,8 @@
 package multipackage
 
 import (
+	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -15,10 +17,13 @@ import (
 )
 
 type MultiPackage struct {
-	SdkVersion         string                            `yaml:"sdk-version"`
-	AbsolutePath       string                            `yaml:"-"`
-	Packages           []string                          `yaml:"packages"`
-	OverrideComponents map[string]*sdkmanifest.Component `yaml:"override-components"`
+	SdkVersion   string   `yaml:"sdk-version"`
+	AbsolutePath string   `yaml:"-"`
+	Packages     []string `yaml:"packages"`
+
+	Components map[string]*sdkmanifest.Component `yaml:"components"`
+	// deprecated in favor of Components
+	DeprecatedOverrideComponents map[string]*sdkmanifest.Component `yaml:"override-components"`
 }
 
 func (m *MultiPackage) AbsolutePackages() []string {
@@ -64,11 +69,29 @@ func ReadFromContents(contents []byte, absPath string) (*MultiPackage, error) {
 	if err := yaml.UnmarshalWithOptions(contents, &obj, yaml.Strict()); err != nil {
 		return nil, err
 	}
-	if obj.OverrideComponents != nil {
-		for name, comp := range obj.OverrideComponents {
+
+	if obj.Components != nil {
+		for name, comp := range obj.Components {
 			comp.Name = name
 		}
 	}
+
+	if obj.DeprecatedOverrideComponents != nil {
+		for name, comp := range obj.DeprecatedOverrideComponents {
+			comp.Name = name
+		}
+
+		if obj.Components != nil {
+			return nil, fmt.Errorf("fields 'components' and 'override-components' cannot be both simultaneously specified. Prefer 'components' as 'override-components' is deprecated")
+		}
+
+		obj.Components = make(map[string]*sdkmanifest.Component)
+		maps.Copy(obj.Components, obj.DeprecatedOverrideComponents)
+
+		// zero it out to make sure we really aren't relying on it past this point
+		obj.DeprecatedOverrideComponents = nil
+	}
+
 	obj.AbsolutePath = absPath
 	return &obj, nil
 }


### PR DESCRIPTION
deprecated the `override-components` field in favor of `components`