### PR TITLE
add sdk-version field to resolution

### DIFF
--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -37,10 +37,19 @@ type MainSuite struct {
 }
 
 type ExpectedResolution struct {
-	ExpectedPackages          int
 	ExpectedDefaultSdkVersion string
 	ExpectedComponents        []string
 	ExpectedImports           int
+	ExpectedSdkVersion        string // assumes
+}
+
+func (r ExpectedResolution) WithSdkVersion(v string) ExpectedResolution {
+	return ExpectedResolution{
+		ExpectedDefaultSdkVersion: r.ExpectedDefaultSdkVersion,
+		ExpectedComponents:        append([]string{}, r.ExpectedComponents...),
+		ExpectedImports:           r.ExpectedImports,
+		ExpectedSdkVersion:        v,
+	}
 }
 
 const someSdkVersion = "0.0.1-whatever"
@@ -55,7 +64,7 @@ func (suite *MainSuite) TestResolveMultiPackageRoot() {
 
 	installSdk(t, []string{someSdkVersion})
 	t.Setenv(assistantconfig.DamlProjectEnvVar, testutil.TestdataPath(t, "another-daml-package"))
-	testResolution(t, ExpectedResolution{1, someSdkVersion, []string{someSdkComponent}, 2})
+	testResolution(t, ExpectedResolution{someSdkVersion, []string{someSdkComponent}, 2, ""})
 }
 
 func (suite *MainSuite) TestResolveMultiPackageSubdir() {
@@ -69,7 +78,7 @@ func (suite *MainSuite) TestResolveMultiPackageSubdir() {
 
 	// this will make daml.yaml in the CWD
 	require.NoError(t, os.Chdir(testutil.TestdataPath(t, "multi-package-with-subdir", "package")))
-	testResolution(t, ExpectedResolution{1, someSdkVersion, []string{someSdkComponent}, 2})
+	testResolution(t, ExpectedResolution{someSdkVersion, []string{someSdkComponent}, 2, ""})
 }
 
 func (suite *MainSuite) TestResolveMultiPackageSdkVersionWithOverrides() {
@@ -227,7 +236,7 @@ func (suite *MainSuite) TestResolveWithDpmSdkVersionEnvVar() {
 
 func testResolution(t *testing.T, expectedPackages ExpectedResolution) {
 	deepResolution := runResolveCommand(t)
-	assert.Len(t, deepResolution.Packages, expectedPackages.ExpectedPackages)
+	assert.Len(t, deepResolution.Packages, 1)
 	assert.Len(t, lo.Values(deepResolution.Packages)[0].Components, len(expectedPackages.ExpectedComponents))
 	assert.Len(t, lo.Values(deepResolution.Packages)[0].Imports, expectedPackages.ExpectedImports)
 	assert.Equal(t, resolution.Kind, deepResolution.Kind)

--- a/cmd/dpm/cmd/lockfile_test.go
+++ b/cmd/dpm/cmd/lockfile_test.go
@@ -136,11 +136,11 @@ func (suite *MainSuite) TestLockfileSdkVersion() {
 		if tc.WorkingDir != PackageWorkingDir { // multi package
 			multiLock, err := packagelock.ReadPackageLock(filepath.Join(dirs.MultiPackageDir, assistantconfig.DpmMultiPackageLockFileName))
 			require.NoError(t, err)
-			assert.Equal(t, tc.ExpectedVersion, multiLock.SdkVersion.Version)
+			assert.Equal(t, tc.ExpectedResolution.ExpectedSdkVersion, multiLock.SdkVersion.Version)
 		} else { //single package
 			lock, err := packagelock.ReadPackageLock(filepath.Join(dirs.DamlPackageDir, assistantconfig.DpmLockFileName))
 			require.NoError(t, err)
-			assert.Equal(t, tc.ExpectedVersion, lock.SdkVersion.Version)
+			assert.Equal(t, tc.ExpectedResolution.ExpectedSdkVersion, lock.SdkVersion.Version)
 		}
 	})
 }

--- a/cmd/dpm/cmd/sdkversion_test.go
+++ b/cmd/dpm/cmd/sdkversion_test.go
@@ -32,7 +32,6 @@ type SdkVersionTestCase struct {
 	Name                                      string
 	MultiPackageSdkVersion, PackageSdkVersion string
 	WorkingDir                                WorkingDir
-	ExpectedVersion                           string
 	ExpectedResolution                        ExpectedResolution
 }
 
@@ -46,10 +45,10 @@ const (
 )
 
 var expectedResolution = ExpectedResolution{
-	1,
 	globalSdkVersion,
 	[]string{someSdkComponent},
-	2}
+	2,
+	""}
 
 var sdkVersionTestCases = []SdkVersionTestCase{
 	{
@@ -57,104 +56,93 @@ var sdkVersionTestCases = []SdkVersionTestCase{
 		MultiPackageSdkVersion: someSdkVersion,
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             MultiPackageWorkingDir,
-		ExpectedVersion:        someSdkVersion,
-		ExpectedResolution:     expectedResolution,
+		ExpectedResolution:     expectedResolution.WithSdkVersion(someSdkVersion),
 	},
 	{
 		Name:                   "2 multi:some pkg:other wd:multi",
 		MultiPackageSdkVersion: someSdkVersion,
 		PackageSdkVersion:      someOtherSdkVersion,
 		WorkingDir:             MultiPackageWorkingDir,
-		ExpectedVersion:        someSdkVersion,
 		ExpectedResolution: ExpectedResolution{
-			1,
 			globalSdkVersion,
 			[]string{someOtherSdkComponent},
-			2},
+			2,
+			someSdkVersion},
 	},
 	{
 		Name:                   "3 multi:some pkg:null wd:multi",
 		MultiPackageSdkVersion: someSdkVersion,
 		PackageSdkVersion:      "null",
 		WorkingDir:             MultiPackageWorkingDir,
-		ExpectedVersion:        someSdkVersion,
-		ExpectedResolution:     expectedResolution,
+		ExpectedResolution:     expectedResolution.WithSdkVersion(someSdkVersion),
 	},
 	{
 		Name:                   "7 multi:null pkg:some wd:multi",
 		MultiPackageSdkVersion: "null",
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             MultiPackageWorkingDir,
-		ExpectedVersion:        globalSdkVersion,
-		ExpectedResolution:     expectedResolution,
+		ExpectedResolution:     expectedResolution.WithSdkVersion(globalSdkVersion),
 	},
 	{
 		Name:                   "9 multi:null pkg:null wd:multi",
 		MultiPackageSdkVersion: "null",
 		PackageSdkVersion:      "null",
 		WorkingDir:             MultiPackageWorkingDir,
-		ExpectedVersion:        globalSdkVersion,
 		ExpectedResolution: ExpectedResolution{
-			1,
 			globalSdkVersion,
 			[]string{},
-			0},
+			0,
+			globalSdkVersion},
 	},
 	{
 		Name:                   "18 multi:null pkg:null wd:pkg",
 		MultiPackageSdkVersion: "null",
 		PackageSdkVersion:      "null",
 		WorkingDir:             PackageWorkingDir,
-		ExpectedVersion:        "null",
 		ExpectedResolution: ExpectedResolution{
-			1,
 			globalSdkVersion,
 			[]string{},
-			0},
+			0,
+			"null"},
 	},
 	{
 		Name:                   "10 multi:some pkg:some wd:pkg",
 		MultiPackageSdkVersion: someSdkVersion,
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             PackageWorkingDir,
-		ExpectedVersion:        someSdkVersion,
-		ExpectedResolution:     expectedResolution,
+		ExpectedResolution:     expectedResolution.WithSdkVersion(someSdkVersion),
 	},
 	{
 		Name:                   "11 multi:some pkg:other wd:pkg",
 		MultiPackageSdkVersion: someSdkVersion,
 		PackageSdkVersion:      someOtherSdkVersion,
 		WorkingDir:             PackageWorkingDir,
-		ExpectedVersion:        someOtherSdkVersion,
 		ExpectedResolution: ExpectedResolution{
-			1,
 			globalSdkVersion,
 			[]string{someOtherSdkComponent},
-			2},
+			2,
+			someOtherSdkVersion},
 	},
 	{
 		Name:                   "12 multi:some pkg:null wd:pkg",
 		MultiPackageSdkVersion: someSdkVersion,
 		PackageSdkVersion:      "null",
 		WorkingDir:             PackageWorkingDir,
-		ExpectedVersion:        someSdkVersion,
-		ExpectedResolution:     expectedResolution,
+		ExpectedResolution:     expectedResolution.WithSdkVersion(someSdkVersion),
 	},
 	{
 		Name:                   "13 multi:other pkg:some wd:pkg",
 		MultiPackageSdkVersion: someOtherSdkVersion,
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             PackageWorkingDir,
-		ExpectedVersion:        someSdkVersion,
-		ExpectedResolution:     expectedResolution,
+		ExpectedResolution:     expectedResolution.WithSdkVersion(someSdkVersion),
 	},
 	{
 		Name:                   "16 multi:null pkg:some wd:pkg",
 		MultiPackageSdkVersion: "null",
 		PackageSdkVersion:      someSdkVersion,
 		WorkingDir:             PackageWorkingDir,
-		ExpectedVersion:        someSdkVersion,
-		ExpectedResolution:     expectedResolution,
+		ExpectedResolution:     expectedResolution.WithSdkVersion(someSdkVersion),
 	},
 }
 
@@ -209,7 +197,7 @@ packages:
 
 			hook(t, tc, dirs)
 
-			if tc.ExpectedVersion == "null" {
+			if tc.ExpectedResolution.ExpectedSdkVersion == "null" {
 				t.Run("assert no active sdk version", func(t *testing.T) {
 					assertNoActiveSdkVersion(t)
 					testResolution(t, tc.ExpectedResolution)
@@ -217,7 +205,7 @@ packages:
 
 			} else {
 				t.Run("assert active sdk version", func(t *testing.T) {
-					assertActiveSdkVersion(t, tc.ExpectedVersion)
+					assertActiveSdkVersion(t, tc.ExpectedResolution.ExpectedSdkVersion)
 					testResolution(t, tc.ExpectedResolution)
 				})
 			}
@@ -228,7 +216,7 @@ packages:
 				assertEnv := func(cmd *exec.Cmd) {
 					wasCalled.Store(true)
 
-					expected := tc.ExpectedVersion
+					expected := tc.ExpectedResolution.ExpectedSdkVersion
 					if expected == "null" {
 						expected = ""
 					}
@@ -251,7 +239,7 @@ packages:
 					_ = createStdTestRootCmdWithPreRunHook(t, assertEnv, c.Use).Execute()
 				}
 
-				if tc.ExpectedVersion == "null" {
+				if tc.ExpectedResolution.ExpectedSdkVersion == "null" {
 					// TODO since in this testcase there's no sdk, no SDK commands will be available
 					// to run (i.e. in the --help) so that we can obtain the injected env var(s).
 					// To test this, we'd need to add an override-component, so that we have at least 1 command

--- a/pkg/assembler/assemblyplan/assemblyplan.go
+++ b/pkg/assembler/assemblyplan/assemblyplan.go
@@ -206,12 +206,14 @@ func (plan *AssemblyPlan) Assemble(ctx context.Context) (*assembler.AssemblyResu
 		return nil, err
 	}
 
+	sdkVersion := assistantconfig.BlankSdkVersion
+	if plan.SdkVersion != nil {
+		plan.SdkVersion.String()
+	}
+	result.ShallowResolution.SdkVersion = sdkVersion
 	for _, cs := range result.ValidatedCommands {
 		for _, c := range cs {
-			c.DpmSdkVersionEnvVar = assistantconfig.BlankSdkVersion
-			if plan.SdkVersion != nil {
-				c.DpmSdkVersionEnvVar = plan.SdkVersion.String()
-			}
+			c.DpmSdkVersionEnvVar = sdkVersion
 		}
 	}
 

--- a/pkg/assembler/assemblyplan/assemblyplan.go
+++ b/pkg/assembler/assemblyplan/assemblyplan.go
@@ -208,7 +208,7 @@ func (plan *AssemblyPlan) Assemble(ctx context.Context) (*assembler.AssemblyResu
 
 	sdkVersion := assistantconfig.BlankSdkVersion
 	if plan.SdkVersion != nil {
-		plan.SdkVersion.String()
+		sdkVersion = plan.SdkVersion.String()
 	}
 	result.ShallowResolution.SdkVersion = sdkVersion
 	for _, cs := range result.ValidatedCommands {

--- a/pkg/resolution/resolution.go
+++ b/pkg/resolution/resolution.go
@@ -32,6 +32,7 @@ type Package struct {
 	Components   map[string]string                   `yaml:"components,omitempty"`
 	ComponentsV2 map[string]map[string]string        `yaml:"componentsV2,omitempty"`
 	Imports      Imports                             `yaml:"imports,omitempty"`
+	SdkVersion   string                              `yaml:"sdk-version"`
 }
 
 // Imports is export Var -> paths list mapping


### PR DESCRIPTION
add a field containing the effective sdk version (which might be `""`) for each package in the `dpm resolve` output