### PR TITLE
support publishing components with arbitrary uri

### DIFF
--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -391,15 +391,28 @@ func (suite *MainSuite) TestComponentPublish() {
 
 func (suite *MainSuite) TestComponentPublishDryRun() {
 	t := suite.T()
-	args := []string{"repo", "publish-component", "--dry-run", "meep", "1.2.3-meep",
-		"-p", "generic=" + testutil.TestdataPath(t, "meepy-component", testutil.OS)}
-	cmd, r, w := createTestRootCmd(t, args...)
-	assert.NoError(t, cmd.Execute())
-	assert.NoError(t, w.Close())
 
-	output, err := io.ReadAll(r)
-	assert.NoError(t, err)
-	assert.Contains(t, string(output), "")
+	doTest := func(t *testing.T, expectedUri string, command []string) {
+		args := append(command, "--dry-run", "--registry", "foo.example.com/a/b",
+			"meep", "1.2.3-meep",
+			"-p", "generic="+testutil.TestdataPath(t, "meepy-component", testutil.OS))
+
+		cmd, r, w := createTestRootCmd(t, args...)
+		assert.NoError(t, cmd.Execute())
+		assert.NoError(t, w.Close())
+
+		output, err := io.ReadAll(r)
+		assert.NoError(t, err)
+		assert.Contains(t, string(output), "destination is "+expectedUri+"\n")
+	}
+
+	t.Run("first party", func(t *testing.T) {
+		doTest(t, "foo.example.com/a/b/components/meep", []string{"repo", "publish-component"})
+	})
+
+	t.Run("third party", func(t *testing.T) {
+		doTest(t, "foo.example.com/a/b/meep", []string{"repo", "push-component"})
+	})
 }
 
 func (suite *MainSuite) TestAssistantVersionCommand() {

--- a/cmd/dpm/cmd/repo/assistant/assistant.go
+++ b/cmd/dpm/cmd/repo/assistant/assistant.go
@@ -36,7 +36,7 @@ func Cmd() *cobra.Command {
 
 			destination := &publish.Destination{
 				Registry: strings.TrimRight(c.Registry, "/"),
-				Artifact: &oci.ComponentArtifact{
+				Artifact: &oci.FirstPartyComponentArtifact{
 					ComponentName: sdkmanifest.AssistantName,
 				},
 			}

--- a/cmd/dpm/cmd/repo/assistant/assistant.go
+++ b/cmd/dpm/cmd/repo/assistant/assistant.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"daml.com/x/assistant/pkg/oci"
 	"daml.com/x/assistant/pkg/publish"
 	"daml.com/x/assistant/pkg/publishcmd"
 	"daml.com/x/assistant/pkg/sdkmanifest"
@@ -23,7 +24,7 @@ func Cmd() *cobra.Command {
 		Example: "  dpm repo publish-dpm 1.2.3-alpha -p linux/arm64=dist/dpm -p windows/amd64=dist/dpm.exe",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			version, err := semver.NewVersion(args[0])
+			version, err := semver.StrictNewVersion(args[0])
 			if err != nil {
 				return fmt.Errorf("invalid version argument: %w", err)
 			}
@@ -31,6 +32,13 @@ func Cmd() *cobra.Command {
 			platforms, err := c.ParsePlatforms()
 			if err != nil {
 				return err
+			}
+
+			destination := &publish.Destination{
+				Registry: strings.TrimRight(c.Registry, "/"),
+				Artifact: &oci.ComponentArtifact{
+					ComponentName: sdkmanifest.AssistantName,
+				},
 			}
 
 			cmd.SilenceUsage = true
@@ -41,7 +49,7 @@ func Cmd() *cobra.Command {
 				DryRun:         c.DryRun,
 				IncludeGitInfo: c.IncludeGitInfo,
 				Annotations:    c.Annotations,
-				Registry:       strings.TrimRight(c.Registry, "/"),
+				Destination:    destination,
 				AuthFilePath:   c.RegistryAuth,
 				Insecure:       c.Insecure,
 				ExtraTags:      c.ExtraTags,

--- a/cmd/dpm/cmd/repo/component/component.go
+++ b/cmd/dpm/cmd/repo/component/component.go
@@ -36,7 +36,7 @@ func Cmd() *cobra.Command {
 
 			destination := &publish.Destination{
 				Registry: strings.TrimRight(c.Registry, "/"),
-				Artifact: &oci.ComponentArtifact{
+				Artifact: &oci.FirstPartyComponentArtifact{
 					ComponentName: name,
 				},
 			}

--- a/cmd/dpm/cmd/repo/pushcomponent/pushcomponent.go
+++ b/cmd/dpm/cmd/repo/pushcomponent/pushcomponent.go
@@ -1,26 +1,29 @@
 // Copyright (c) 2017-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package component
+package pushcomponent
 
 import (
 	"fmt"
 	"strings"
 
-	"daml.com/x/assistant/pkg/oci"
+	ociconsts "daml.com/x/assistant/pkg/oci"
 	"daml.com/x/assistant/pkg/publish"
 	"daml.com/x/assistant/pkg/publishcmd"
 	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2/registry"
 )
 
 func Cmd() *cobra.Command {
 	c := publishcmd.PublishCmd{}
 
+	// TODO stop publishing a tag for every platform
 	cmd := &cobra.Command{
-		Use:     "publish-component <name> <version>",
+		Use:     "push-component <name> <version>",
 		Short:   "Publish a component to an OCI registry",
-		Example: "  dpm repo publish-component foo 1.2.3-alpha -p linux/amd64=dist/foo-linux -p darwin/arm64=dist/foo-darwin",
+		Long:    "Will publish the component (OCI index) to <registry>/<name>:<version>",
+		Example: "  dpm repo push-component foo 1.2.3-alpha -p linux/amd64=dist/foo-linux -p darwin/arm64=dist/foo-darwin --registry 'example.com/some/path'",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
@@ -34,10 +37,14 @@ func Cmd() *cobra.Command {
 				return err
 			}
 
+			ref, err := registry.ParseReference(fmt.Sprintf("%s/%s", strings.TrimRight(c.Registry, "/"), name))
+			if err != nil {
+				return err
+			}
 			destination := &publish.Destination{
-				Registry: strings.TrimRight(c.Registry, "/"),
-				Artifact: &oci.ComponentArtifact{
-					ComponentName: name,
+				Registry: ref.Registry,
+				Artifact: &ociconsts.ThirdPartyComponentArtifact{
+					ComponentRepo: ref.Repository,
 				},
 			}
 
@@ -68,6 +75,7 @@ func Cmd() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&c.ExtraTags, "extra-tags", "t", []string{}, "publish extra tags besides the semver")
 
 	cmd.Flags().StringVar(&c.Registry, "registry", "", "OCI registry to use for pushing")
+	cmd.MarkFlagRequired(publishcmd.RegistryFlagName)
 	cmd.Flags().BoolVar(&c.Insecure, "insecure", false, "use http instead of https for OCI registry")
 	cmd.Flags().StringVar(&c.RegistryAuth, "auth", "", "path to a config file similar to docker’s config.json to use for authenticating to the OCI registry. Defaults to docker's config.json")
 

--- a/cmd/dpm/cmd/repo/pushcomponent/pushcomponent.go
+++ b/cmd/dpm/cmd/repo/pushcomponent/pushcomponent.go
@@ -43,7 +43,7 @@ func Cmd() *cobra.Command {
 			}
 			destination := &publish.Destination{
 				Registry: ref.Registry,
-				Artifact: &ociconsts.ThirdPartyComponentArtifact{
+				Artifact: &ociconsts.ComponentArtifact{
 					ComponentRepo: ref.Repository,
 				},
 			}

--- a/cmd/dpm/cmd/repo/repo.go
+++ b/cmd/dpm/cmd/repo/repo.go
@@ -8,6 +8,7 @@ import (
 	componentPublish "daml.com/x/assistant/cmd/dpm/cmd/repo/component"
 	"daml.com/x/assistant/cmd/dpm/cmd/repo/dar"
 	"daml.com/x/assistant/cmd/dpm/cmd/repo/promote"
+	"daml.com/x/assistant/cmd/dpm/cmd/repo/pushcomponent"
 	"daml.com/x/assistant/cmd/dpm/cmd/repo/resolve"
 	"daml.com/x/assistant/cmd/dpm/cmd/repo/sdkmanifest"
 	"daml.com/x/assistant/cmd/dpm/cmd/repo/tags"
@@ -27,6 +28,7 @@ func Cmd(config *assistantconfig.Config) *cobra.Command {
 	cmd.AddCommand(sdkmanifest.Cmd())
 	cmd.AddCommand(tarball.Cmd())
 	cmd.AddCommand(componentPublish.Cmd())
+	cmd.AddCommand(pushcomponent.Cmd())
 	cmd.AddCommand(assistant.Cmd())
 	cmd.AddCommand(resolve.Cmd())
 	cmd.AddCommand(promote.Cmd())

--- a/cmd/dpm/cmd/repo/resolve/resolve.go
+++ b/cmd/dpm/cmd/repo/resolve/resolve.go
@@ -149,7 +149,7 @@ func resolveFromPublishConfig(ctx context.Context, client *assistantremote.Remot
 func resolveAll(ctx context.Context, client *assistantremote.Remote, componentTags map[string]string) (map[string]*semver.Version, error) {
 	resolved := map[string]*semver.Version{}
 	for comp, tag := range componentTags {
-		version, err := ociindex.ResolveTag(ctx, client, &oci.ComponentArtifact{ComponentName: comp}, tag)
+		version, err := ociindex.ResolveTag(ctx, client, &oci.FirstPartyComponentArtifact{ComponentName: comp}, tag)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/dpm/cmd/repo_test.go
+++ b/cmd/dpm/cmd/repo_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -271,6 +272,26 @@ func (suite *RepoSuite) TestPublishDar() {
 	}
 	cmd.SetArgs(args)
 	require.NoError(t, cmd.Execute())
+}
+
+func (suite *RepoSuite) TestPublishThirdPartyComponents() {
+	t := suite.T()
+	_, _ = testutil.StartRegistry(t)
+	uri := fmt.Sprintf("%s/x/y/z", os.Getenv(assistantconfig.OciRegistryEnvVar))
+
+	args := []string{"repo", "push-component", "meep", "1.2.3",
+		"-p", "windows/amd64=" + testutil.TestdataPath(t, "meepy-component", "windows"),
+		"-p", "linux/amd64=" + testutil.TestdataPath(t, "meepy-component", "unix"),
+		"-p", "darwin/amd64=" + testutil.TestdataPath(t, "meepy-component", "unix"),
+		"-p", "darwin/arm64=" + testutil.TestdataPath(t, "meepy-component", "unix"),
+		"--registry", uri,
+	}
+
+	if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
+		args = append(args, "--insecure")
+	}
+
+	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
 }
 
 func listTags(t *testing.T, component, registry string) []string {

--- a/docs-internal/src/cli/dpm_repo.rst
+++ b/docs-internal/src/cli/dpm_repo.rst
@@ -30,6 +30,7 @@ SEE ALSO
 * :ref:`dpm repo publish-component <dpm_repo_publish-component>` 	 - Publish a component to an OCI registry
 * :ref:`dpm repo publish-dpm <dpm_repo_publish-dpm>` 	 - Publish the assistant to an OCI registry
 * :ref:`dpm repo publish-sdk-manifest <dpm_repo_publish-sdk-manifest>` 	 - publish an sdk's manifest
+* :ref:`dpm repo push-component <dpm_repo_push-component>` 	 - Publish a component to an OCI registry
 * :ref:`dpm repo resolve-tags <dpm_repo_resolve-tags>` 	 - resolve the tag of one or more components to corresponding (semantic) versions
 * :ref:`dpm repo tags <dpm_repo_tags>` 	 - list published tags of a component
 

--- a/docs-internal/src/cli/dpm_repo_push-component.rst
+++ b/docs-internal/src/cli/dpm_repo_push-component.rst
@@ -1,0 +1,47 @@
+Dpm Repo Push-Component
+=======================
+
+.. _dpm_repo_push-component:
+
+dpm repo push-component
+-----------------------
+
+Publish a component to an OCI registry
+
+Synopsis
+~~~~~~~~
+
+
+Will publish the component (OCI index) to <registry>/<name>:<version>
+
+::
+
+  dpm repo push-component <name> <version> [flags]
+
+Examples
+~~~~~~~~
+
+::
+
+    dpm repo push-component foo 1.2.3-alpha -p linux/amd64=dist/foo-linux -p darwin/arm64=dist/foo-darwin --registry 'example.com/some/path'
+
+Options
+~~~~~~~
+
+::
+
+  -a, --annotations stringToString   annotations to include in the published OCI artifact (default [])
+      --auth string                  path to a config file similar to docker’s config.json to use for authenticating to the OCI registry. Defaults to docker's config.json
+  -d, --dry-run                      don't actually push to the registry
+  -t, --extra-tags strings           publish extra tags besides the semver
+  -h, --help                         help for push-component
+  -g, --include-git-info             include git info as annotations on the published manifest
+      --insecure                     use http instead of https for OCI registry
+  -p, --platform stringToString      REQUIRED <os>/<arch>=<path-to-component> or generic=<path-to-component> (default [])
+      --registry string              OCI registry to use for pushing
+
+SEE ALSO
+~~~~~~~~
+
+* :ref:`dpm repo <dpm_repo>` 	 - 
+

--- a/docs-internal/src/cli/index.rst
+++ b/docs-internal/src/cli/index.rst
@@ -15,6 +15,7 @@
    dpm_repo_publish-component
    dpm_repo_publish-dpm
    dpm_repo_publish-sdk-manifest
+   dpm_repo_push-component
    dpm_repo_resolve-tags
    dpm_repo_tags
    dpm_resolve

--- a/pkg/assistantconfig/assistantremote/remote_test.go
+++ b/pkg/assistantconfig/assistantremote/remote_test.go
@@ -16,7 +16,6 @@ import (
 	"daml.com/x/assistant/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"oras.land/oras-go/v2/registry"
 )
 
 type FakeRegistry struct {
@@ -28,12 +27,6 @@ const expectedSuccessBody = "okdokey"
 // Tests authenticating to a registry via a docker credsStore
 // https://docs.docker.com/reference/cli/docker/login/#credential-stores
 func TestGetRemote(t *testing.T) {
-
-	parsed, err := registry.ParseReference("foo.example.com/a/b/c:1.2.3")
-	require.NoError(t, err)
-
-	print(parsed.Registry)
-
 	withMagicEnv(t, func() {
 		dir, deleteFn, err := utils.MkdirTemp("", "")
 		require.NoError(t, err)

--- a/pkg/assistantconfig/assistantremote/remote_test.go
+++ b/pkg/assistantconfig/assistantremote/remote_test.go
@@ -16,6 +16,7 @@ import (
 	"daml.com/x/assistant/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/registry"
 )
 
 type FakeRegistry struct {
@@ -27,6 +28,12 @@ const expectedSuccessBody = "okdokey"
 // Tests authenticating to a registry via a docker credsStore
 // https://docs.docker.com/reference/cli/docker/login/#credential-stores
 func TestGetRemote(t *testing.T) {
+
+	parsed, err := registry.ParseReference("foo.example.com/a/b/c:1.2.3")
+	require.NoError(t, err)
+
+	print(parsed.Registry)
+
 	withMagicEnv(t, func() {
 		dir, deleteFn, err := utils.MkdirTemp("", "")
 		require.NoError(t, err)

--- a/pkg/oci/artifact.go
+++ b/pkg/oci/artifact.go
@@ -17,6 +17,16 @@ type ComponentArtifact struct {
 	ComponentName string
 }
 
+type ThirdPartyComponentArtifact struct {
+	ComponentRepo string
+}
+
+func (a *ThirdPartyComponentArtifact) RepoName() string {
+	return a.ComponentRepo
+}
+func (a *ThirdPartyComponentArtifact) ArtifactType() string  { return ComponentArtifactType }
+func (a *ThirdPartyComponentArtifact) FileMediaType() string { return ComponentFileMediaType }
+
 type DarArtifact struct {
 	DarName string
 }

--- a/pkg/oci/artifact.go
+++ b/pkg/oci/artifact.go
@@ -13,25 +13,25 @@ type Dar interface {
 	DarRepoName() string
 }
 
-type ComponentArtifact struct {
+type FirstPartyComponentArtifact struct {
 	ComponentName string
 }
 
-type ThirdPartyComponentArtifact struct {
+type ComponentArtifact struct {
 	ComponentRepo string
 }
 
-func (a *ThirdPartyComponentArtifact) RepoName() string {
+func (a *ComponentArtifact) RepoName() string {
 	return a.ComponentRepo
 }
-func (a *ThirdPartyComponentArtifact) ArtifactType() string  { return ComponentArtifactType }
-func (a *ThirdPartyComponentArtifact) FileMediaType() string { return ComponentFileMediaType }
+func (a *ComponentArtifact) ArtifactType() string  { return ComponentArtifactType }
+func (a *ComponentArtifact) FileMediaType() string { return ComponentFileMediaType }
 
 type DarArtifact struct {
 	DarName string
 }
 
-func (a *ComponentArtifact) RepoName() string {
+func (a *FirstPartyComponentArtifact) RepoName() string {
 	return ComponentRepoPrefix + a.ComponentName
 }
 
@@ -39,8 +39,8 @@ func (a *DarArtifact) RepoName() string {
 	return DarRepoPrefix + a.DarName
 }
 
-func (a *ComponentArtifact) ArtifactType() string  { return ComponentArtifactType }
-func (a *ComponentArtifact) FileMediaType() string { return ComponentFileMediaType }
+func (a *FirstPartyComponentArtifact) ArtifactType() string  { return ComponentArtifactType }
+func (a *FirstPartyComponentArtifact) FileMediaType() string { return ComponentFileMediaType }
 
 func (a *DarArtifact) ArtifactType() string  { return DarArtifactType }
 func (a *DarArtifact) FileMediaType() string { return DarFileMediaType }

--- a/pkg/publish/destination.go
+++ b/pkg/publish/destination.go
@@ -1,0 +1,62 @@
+package publish
+
+import (
+	"fmt"
+
+	ociconsts "daml.com/x/assistant/pkg/oci"
+)
+
+//
+//type Destination interface {
+//	GetRegistry() string
+//	Artifact() ociconsts.Artifact
+//	String() string
+//}
+//
+//type ThirdPartyDestination struct {
+//	reference *registry.Reference
+//}
+//
+//func (t ThirdPartyDestination) IsThirdParty() bool {
+//	return true
+//}
+//
+//func (t ThirdPartyDestination) GetRef() *registry.Reference {
+//	return t.reference
+//}
+//
+//func (t ThirdPartyDestination) Artifact() ociconsts.Artifact {
+//	return &ociconsts.ThirdPartyComponentArtifact{
+//		ComponentRepo: t.reference.Repository,
+//	}
+//}
+//
+//type FirstPartyDestination struct {
+//	reference *registry.Reference
+//}
+//
+//func (f FirstPartyDestination) IsThirdParty() bool {
+//	return false
+//}
+//
+//func (f FirstPartyDestination) GetRef() *registry.Reference {
+//	return f.reference
+//}
+//
+//func (f FirstPartyDestination) Artifact() ociconsts.Artifact {
+//	return &ociconsts.ComponentArtifact{
+//		ComponentName:
+//	}
+//}
+//
+//var _ Destination = (*FirstPartyDestination)(nil)
+//var _ Destination = (*ThirdPartyDestination)(nil)
+
+type Destination struct {
+	Registry string
+	Artifact ociconsts.Artifact
+}
+
+func (d *Destination) String() string {
+	return fmt.Sprintf("%s/%s", d.Registry, d.Artifact.RepoName())
+}

--- a/pkg/publish/destination.go
+++ b/pkg/publish/destination.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package publish
 
 import (
@@ -5,52 +8,6 @@ import (
 
 	ociconsts "daml.com/x/assistant/pkg/oci"
 )
-
-//
-//type Destination interface {
-//	GetRegistry() string
-//	Artifact() ociconsts.Artifact
-//	String() string
-//}
-//
-//type ThirdPartyDestination struct {
-//	reference *registry.Reference
-//}
-//
-//func (t ThirdPartyDestination) IsThirdParty() bool {
-//	return true
-//}
-//
-//func (t ThirdPartyDestination) GetRef() *registry.Reference {
-//	return t.reference
-//}
-//
-//func (t ThirdPartyDestination) Artifact() ociconsts.Artifact {
-//	return &ociconsts.ThirdPartyComponentArtifact{
-//		ComponentRepo: t.reference.Repository,
-//	}
-//}
-//
-//type FirstPartyDestination struct {
-//	reference *registry.Reference
-//}
-//
-//func (f FirstPartyDestination) IsThirdParty() bool {
-//	return false
-//}
-//
-//func (f FirstPartyDestination) GetRef() *registry.Reference {
-//	return f.reference
-//}
-//
-//func (f FirstPartyDestination) Artifact() ociconsts.Artifact {
-//	return &ociconsts.ComponentArtifact{
-//		ComponentName:
-//	}
-//}
-//
-//var _ Destination = (*FirstPartyDestination)(nil)
-//var _ Destination = (*ThirdPartyDestination)(nil)
 
 type Destination struct {
 	Registry string

--- a/pkg/publish/publish.go
+++ b/pkg/publish/publish.go
@@ -41,7 +41,7 @@ type Config struct {
 	Annotations            map[string]string
 	ExtraTags              []string
 
-	Registry     string
+	Destination  *Destination
 	AuthFilePath string
 	Insecure     bool
 }
@@ -55,7 +55,7 @@ func (config *Config) RequiredAnnotations() ociconsts.DescriptorAnnotations {
 
 func (config *Config) indexOpts(tag string, descriptors []v1.Descriptor) ociindex.Opts {
 	return ociindex.Opts{
-		Artifact:            &ociconsts.ComponentArtifact{ComponentName: config.Name},
+		Artifact:            config.Destination.Artifact,
 		Tag:                 tag,
 		Manifests:           descriptors,
 		ExtraAnnotations:    config.Annotations,
@@ -73,6 +73,8 @@ func New(config *Config, printer utils.RawPrinter) *Publisher {
 }
 
 func (p *Publisher) Publish(ctx context.Context) (err error) {
+	p.printer.Println("destination is " + p.config.Destination.String())
+	
 	var pushOps []*ocipusher.PushOperation
 	if p.config.Name != sdkmanifest.AssistantName {
 		pushOps, err = p.prepareComponents(ctx)
@@ -93,11 +95,11 @@ func (p *Publisher) Publish(ctx context.Context) (err error) {
 		return nil
 	}
 
-	if p.config.Registry == "" {
+	if p.config.Destination == nil {
 		return fmt.Errorf("--registy must be provided when not in dry-run mode")
 	}
 
-	client, err := assistantremote.New(p.config.Registry, p.config.AuthFilePath, p.config.Insecure)
+	client, err := assistantremote.New(p.config.Destination.Registry, p.config.AuthFilePath, p.config.Insecure)
 	if err != nil {
 		return err
 	}
@@ -147,7 +149,7 @@ func (p *Publisher) Publish(ctx context.Context) (err error) {
 
 	if p.config.ExtraTags != nil && len(p.config.ExtraTags) > 0 {
 		p.printer.Println("pushing extra tags...")
-		err := ociindex.Tag(ctx, client, &ociconsts.ComponentArtifact{ComponentName: p.config.Name}, p.config.Version, p.config.ExtraTags)
+		err := ociindex.Tag(ctx, client, p.config.Destination.Artifact, p.config.Version, p.config.ExtraTags)
 		if err != nil {
 			return err
 		}
@@ -254,11 +256,9 @@ func (p *Publisher) prepare(ctx context.Context, platform simpleplatform.Platfor
 		}
 		maps.Copy(annotations, gitAnnotations)
 	}
-	var artifact ociconsts.Artifact
-	artifact = &ociconsts.ComponentArtifact{ComponentName: p.config.Name}
 
 	opts := ocipusher.Opts{
-		Artifact:            artifact,
+		Artifact:            p.config.Destination.Artifact,
 		RawTag:              p.config.Version.String(),
 		Dir:                 dir,
 		RequiredAnnotations: p.config.RequiredAnnotations(),

--- a/pkg/publishcmd/publishcmd.go
+++ b/pkg/publishcmd/publishcmd.go
@@ -11,6 +11,7 @@ import (
 
 const PlatformFlagName = "platform"
 const FileFlagName = "file"
+const RegistryFlagName = "registry"
 
 type PublishCmd struct {
 	DryRun, IncludeGitInfo bool

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -5,6 +5,7 @@ package testutil
 
 import (
 	"context"
+	"fmt"
 	"net/http/httptest"
 	"path/filepath"
 	"runtime"
@@ -38,6 +39,27 @@ func TestdataPath(t *testing.T, path ...string) string {
 	p := []string{filepath.Dir(file), "testdata"}
 	p = append(p, path...)
 	return filepath.Join(p...)
+}
+
+// PushComponentUri can be used like so
+//
+//	args := testutil.PushComponentUri(registry, "foo", "some/prefix", "4.5.6", testutil.TestdataPath(t, "meepy-component", "unix"), "latest")
+//	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
+//
+// and that will push "foo" to "some/prefix/foo"
+func PushComponentUri(registry *httptest.Server, name, repo, tag, pathToComponent string, extraTags ...string) (args []string) {
+	uri := fmt.Sprintf("%s/%s", getRemote(registry).Registry, repo)
+
+	args = []string{"repo", "push-component", name, tag, "--registry", uri, "-p", "generic=" + pathToComponent}
+
+	if strings.HasPrefix(registry.URL, "http://") {
+		args = append(args, "--insecure")
+	}
+	for _, t := range extraTags {
+		args = append(args, "--extra-tags", t)
+	}
+
+	return args
 }
 
 func PushComponent(t *testing.T, ctx context.Context, registry *httptest.Server, componentName, tag, pathToComponent string, extraTags ...string) {

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -49,7 +49,7 @@ func PushComponent(t *testing.T, ctx context.Context, registry *httptest.Server,
 		Version: v,
 	}
 	opts := ocipusher.Opts{
-		Artifact:            &ociconsts.ComponentArtifact{ComponentName: componentName},
+		Artifact:            &ociconsts.FirstPartyComponentArtifact{ComponentName: componentName},
 		RawTag:              tag,
 		Dir:                 pathToComponent,
 		RequiredAnnotations: requiredAnnotations,
@@ -62,7 +62,7 @@ func PushComponent(t *testing.T, ctx context.Context, registry *httptest.Server,
 	require.NoError(t, err)
 
 	indexOpts := ociindex.Opts{
-		Artifact:            &ociconsts.ComponentArtifact{ComponentName: componentName},
+		Artifact:            &ociconsts.FirstPartyComponentArtifact{ComponentName: componentName},
 		Tag:                 tag,
 		Manifests:           []v1.Descriptor{*desc},
 		ExtraAnnotations:    map[string]string{},
@@ -72,7 +72,7 @@ func PushComponent(t *testing.T, ctx context.Context, registry *httptest.Server,
 	require.NoError(t, err)
 
 	if len(extraTags) > 0 {
-		err = ociindex.Tag(ctx, r, &ociconsts.ComponentArtifact{ComponentName: componentName}, v, extraTags)
+		err = ociindex.Tag(ctx, r, &ociconsts.FirstPartyComponentArtifact{ComponentName: componentName}, v, extraTags)
 		require.NoError(t, err)
 	}
 }


### PR DESCRIPTION
introducing a new command for publishing components that supports usage of arbitrary URI instead of assuming DA-specific `<registry>/components/<name>` release-drive layout


Tested with oras too:

```
go run ./cmd/dpm/main.go repo push-component meep 1.2.3 --registry localhost:5000/a/b --insecure -p generic=./pkg/testutil/testdata/meepy-component/unix
destination is localhost:5000/a/b/meep
📦 Validating "generic" component manifest...
Component manifest is valid ✅

📦 Checking "generic" includes license file...
License file included ✅

Content:
/Users/sammyabed/dpm/pkg/testutil/testdata/meepy-component/unix dir 224
/Users/sammyabed/dpm/pkg/testutil/testdata/meepy-component/unix/LICENSE file 24
/Users/sammyabed/dpm/pkg/testutil/testdata/meepy-component/unix/component.yaml file 506
/Users/sammyabed/dpm/pkg/testutil/testdata/meepy-component/unix/just-a-dir dir 96
/Users/sammyabed/dpm/pkg/testutil/testdata/meepy-component/unix/just-a-dir/xyz file 4
/Users/sammyabed/dpm/pkg/testutil/testdata/meepy-component/unix/meep file 42
/Users/sammyabed/dpm/pkg/testutil/testdata/meepy-component/unix/show-env-vars file 28

Pushing "\x1b[32mlocalhost:5000/a/b/meep:1.2.3.generic\x1b[0m"...

{
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "digest": "sha256:c95febdaa1c06d956ae3b1fcfd188c994639e83e6ff425c560106258f2195719",
  "size": 2277,
  "annotations": {
    "com.digitalasset.name": "meep",
    "com.digitalasset.version": "1.2.3",
    "org.opencontainers.image.created": "2026-04-15T14:17:59Z"
  },
  "artifactType": "application/vnd.component.artifact"
}
successfully published localhost:5000/a/b/meep:1.2.3.generic
📖 Pushing index meep/1.2.3

{
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "digest": "sha256:b01a9b9155108d485ab04da9bc7bba3494ee9fc636fc65f767376ab4d2b77fdf",
  "size": 567
}
successfully published index meep/1.2.3
```

```
ORAS_CACHE=./oras oras pull localhost:5000/a/b/meep:1.2.3 --output meep
✓ Pulled      just-a-dir                                                                                       136/136  B 100.00%    1ms
  └─ sha256:45b92f62fcbba321ed76d2731d1f1ee46e6f8fff932c22565b005686c8355dc4
✓ Pulled      LICENSE                                                                                            24/24  B 100.00%  303µs
  └─ sha256:44879cbe9668207c954713eeae6013e02562f69ed59b6fbbc358c735b2ca5996
✓ Pulled      component.yaml                                                                                   506/506  B 100.00%  231µs
  └─ sha256:e39031bb80818110853aa0dc5a367a0ff09fd753ebb22b1aae4715e61d4c8e4e
✓ Pulled      meep                                                                                               42/42  B 100.00%  213µs
  └─ sha256:e20c85d136e4a36168f16fad0e305dafc5164a463bbe3996a18cc366611f214c
✓ Pulled      show-env-vars                                                                                      28/28  B 100.00%  261µs
  └─ sha256:3164be774369c36a4a0c65ae279a31ba765835a18b08df5aa879c984717b8fc9
✓ Pulled      application/vnd.oci.image.manifest.v1+json                                                     2.22/2.22 kB 100.00%  140µs
  └─ sha256:517c687a52f07c382512a7dea3e4b32d8eb829bac43ddbcd857a8e295bd51de8
✓ Pulled      application/vnd.oci.image.index.v1+json                                                          567/567  B 100.00%   74µs
  └─ sha256:b4badbe21e269c88ba649f16f3665c99ab4c94bd895f991d8dc7166f7143ecac
Skipped pulling layers without file name in "org.opencontainers.image.title"
Use 'oras copy localhost:5000/a/b/meep:1.2.3 --to-oci-layout <layout-dir>' to pull all layers.
```
```
oras manifest fetch localhost:5000/a/b/meep:1.2.3 | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "artifactType": "application/vnd.component.artifact",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:c95febdaa1c06d956ae3b1fcfd188c994639e83e6ff425c560106258f2195719",
      "size": 2277,
      "annotations": {
        "com.digitalasset.name": "meep",
        "com.digitalasset.version": "1.2.3",
        "org.opencontainers.image.created": "2026-04-15T14:17:59Z"
      },
      "artifactType": "application/vnd.component.artifact"
    }
  ],
  "annotations": {
    "com.digitalasset.name": "meep",
    "com.digitalasset.version": "1.2.3"
  }
}
```


