### PR TITLE
Update URI testing to use random paths

### DIFF
--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -922,9 +922,13 @@ func (suite *MainSuite) TestInstallPackageMultiRegistry() {
 
 	t.Cleanup(func() { require.NoError(t, os.Chdir(cwd)) })
 
-	// TODO - Update dpm repo publish-component to be able to handle different oci path with assuming a structure
-	testutil.PushComponent(t, ctx, reg, "meep", "1.2.3", testutil.TestdataPath(t, "meepy-component", testutil.OS))
-	testutil.PushComponent(t, ctx, altReg, "rando", "1.2.4", testutil.TestdataPath(t, "components", "rando"))
+	args := testutil.PushComponentUri(reg, "meep", "foo/bar", "1.2.3", testutil.TestdataPath(t, "meepy-component", testutil.OS))
+	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
+
+	args = testutil.PushComponentUri(altReg, "rando", "bar/foo", "1.2.4", testutil.TestdataPath(t, "components", "rando"))
+	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
+
+	// Want to ensure that version is still using handleOCI - push up using internal DA pushComponent
 	testutil.PushComponent(t, ctx, altReg, "needy", "1.2.5", testutil.TestdataPath(t, "components", "needy", testutil.OS))
 
 	require.NoError(t, os.Chdir(testutil.TestdataPath(t, "multi-registry", testutil.OS)))

--- a/pkg/testutil/testdata/multi-registry/unix/daml.yaml
+++ b/pkg/testutil/testdata/multi-registry/unix/daml.yaml
@@ -1,10 +1,8 @@
 components:
   # TODO - replace /components/ with something more "random" for better uri representation
   meep:
-    uri: ${TEST_DPM_REGISTRY}/components/meep:1.2.3
-    #TODO uri: ${TEST_DPM_REGISTRY}/foo/bar/meep:1.2.3
+    uri: ${TEST_DPM_REGISTRY}/foo/bar/meep:1.2.3
   rando:
-    uri: ${TEST_ALT_DPM_REGISTRY}/components/rando:1.2.4
-    # TODO uri: ${TEST_ALT_DPM_REGISTRY}/bar/foo/rando:1.2.4
+    uri: ${TEST_ALT_DPM_REGISTRY}/bar/foo/rando:1.2.4
   needy:
     version: 1.2.5

--- a/pkg/testutil/testdata/multi-registry/unix/daml.yaml
+++ b/pkg/testutil/testdata/multi-registry/unix/daml.yaml
@@ -1,5 +1,4 @@
 components:
-  # TODO - replace /components/ with something more "random" for better uri representation
   meep:
     uri: ${TEST_DPM_REGISTRY}/foo/bar/meep:1.2.3
   rando:

--- a/pkg/testutil/testdata/multi-registry/windows/daml.yaml
+++ b/pkg/testutil/testdata/multi-registry/windows/daml.yaml
@@ -1,10 +1,8 @@
 components:
   # TODO - replace /components/ with something more "random" for better uri representation
   meep:
-    uri: ${TEST_DPM_REGISTRY}/components/meep:1.2.3
-    #TODO uri: ${TEST_DPM_REGISTRY}/foo/bar/meep:1.2.3
+    uri: ${TEST_DPM_REGISTRY}/foo/bar/meep:1.2.3
   rando:
-    uri: ${TEST_ALT_DPM_REGISTRY}/components/rando:1.2.4
-    # TODO uri: ${TEST_ALT_DPM_REGISTRY}/bar/foo/rando:1.2.4
+    uri: ${TEST_ALT_DPM_REGISTRY}/bar/foo/rando:1.2.4
   needy:
     version: 1.2.5

--- a/pkg/testutil/testdata/multi-registry/windows/daml.yaml
+++ b/pkg/testutil/testdata/multi-registry/windows/daml.yaml
@@ -1,5 +1,4 @@
 components:
-  # TODO - replace /components/ with something more "random" for better uri representation
   meep:
     uri: ${TEST_DPM_REGISTRY}/foo/bar/meep:1.2.3
   rando:

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -41,12 +41,6 @@ func TestdataPath(t *testing.T, path ...string) string {
 	return filepath.Join(p...)
 }
 
-// PushComponentUri can be used like so
-//
-//	args := testutil.PushComponentUri(registry, "foo", "some/prefix", "4.5.6", testutil.TestdataPath(t, "meepy-component", "unix"), "latest")
-//	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
-//
-// and that will push "foo" to "some/prefix/foo"
 func PushComponentUri(registry *httptest.Server, name, repo, tag, pathToComponent string, extraTags ...string) (args []string) {
 	uri := fmt.Sprintf("%s/%s", getRemote(registry).Registry, repo)
 


### PR DESCRIPTION
Updated URI testing to use random repo paths instead of the hardcoded constants from using PushComponent functionality. Use new PushComponentUri in place and update daml.yaml testfiles to use random paths in URI