### PR TITLE
forward os signals to child process

### DIFF
--- a/pkg/assistant/assistant.go
+++ b/pkg/assistant/assistant.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 
 	"daml.com/x/assistant/pkg/assembler"
@@ -233,7 +234,14 @@ func (da *DamlAssistant) execSdkCommand(ctx context.Context, path string, args [
 		da.CmdPreRunHook(cmd)
 	}
 
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Start(); err != nil {
+		return 0, fmt.Errorf("failed to spawn command subprocess. %w", err)
+	}
+
+	cancel := forwardSignals(cmd)
+	defer cancel()
+
+	if err := cmd.Wait(); err != nil {
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
 			return exitError.ExitCode(), nil
@@ -242,4 +250,21 @@ func (da *DamlAssistant) execSdkCommand(ctx context.Context, path string, args [
 		}
 	}
 	return 0, nil
+}
+
+func forwardSignals(cmd *exec.Cmd) (cancel func()) {
+	sigCh := make(chan os.Signal)
+	signal.Notify(sigCh)
+
+	go func() {
+		for sig := range sigCh {
+			if cmd.Process != nil {
+				_ = cmd.Process.Signal(sig)
+			}
+		}
+	}()
+
+	return func() {
+		signal.Stop(sigCh)
+	}
 }


### PR DESCRIPTION
Fix a bug where dpm doesn't forward signals to component's process, e.g. the process lingers even when dpm is terminated:
<img width="623" height="231" alt="image" src="https://github.com/user-attachments/assets/b1982581-9591-4d31-86f4-3139c7997fe9" />

where sigs is:
```
#!/usr/bin/env bash
set -euo pipefail

echo "PID $$ started (parent: $PPID)"

# handler function
handle_signal() {
  local sig="$1"
  echo "[$(date +%T)] $$ received signal from parent: $sig"
}

trap 'handle_signal SIGINT' INT
trap 'handle_signal SIGTERM' TERM
trap 'handle_signal SIGHUP' HUP
trap 'handle_signal SIGQUIT' QUIT

while true; do
  echo "i'm $$"
  sleep 5
done
```
