### PR TITLE
oci annotations revamp

### DIFF
--- a/cmd/dpm/cmd/repo_test.go
+++ b/cmd/dpm/cmd/repo_test.go
@@ -16,9 +16,12 @@ import (
 	root "daml.com/x/assistant"
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/licenseutils"
+	ociconsts "daml.com/x/assistant/pkg/oci"
+	"daml.com/x/assistant/pkg/ociindex"
 	"daml.com/x/assistant/pkg/ocilister"
 	"daml.com/x/assistant/pkg/sdkmanifest"
 	"daml.com/x/assistant/pkg/testutil"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -201,6 +204,86 @@ func (suite *RepoSuite) TestResolveLatest() {
 		assert.NotContains(t, string(output), c.tag)
 		assert.Contains(t, string(output), "version: 1.2.3")
 	}
+}
+
+func (suite *RepoSuite) TestLegacyOciAnnotation() {
+	t := suite.T()
+	const sdkVersion = "0.0.1-whatever"
+
+	//fetchManifest := func(t *testing.T, ref string) map[string]any {
+	//	ctx := t.Context()
+	//	repo, err := remote.NewRepository(ref)
+	//	require.NoError(t, err)
+	//
+	//	desc, err := repo.Resolve(t.Context(), "")
+	//	require.NoError(t, err)
+	//
+	//	// Fetch manifest content
+	//	rc, err := repo.Fetch(ctx, desc)
+	//	require.NoError(t, err)
+	//	defer rc.Close()
+	//
+	//	bytes, err := io.ReadAll(rc)
+	//	require.NoError(t, err)
+	//
+	//	var m map[string]any
+	//	require.NoError(t, json.Unmarshal(bytes, m))
+	//
+	//	return
+	//}
+
+	assertAnnotations := func(t *testing.T, annotations map[string]string, expectedAnnotations ...string) {
+		for _, a := range expectedAnnotations {
+			assert.Contains(t, annotations, a)
+		}
+	}
+
+	doTest := func(t *testing.T) {
+		tmpDpmHome := t.TempDir()
+		t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDpmHome)
+
+		publishComponents(t)
+
+		// push assembly
+		cmd := createStdTestRootCmd(t)
+		args := []string{"repo", "publish-sdk-manifest", "-t", "latest",
+			"-f", testutil.TestdataPath(t, "publish.yaml"), "--extra-tags", "foo"}
+		cmd.SetArgs(appendRegistryArgsFromEnv(args))
+		require.NoError(t, cmd.Execute())
+
+		// install it
+		cmd = createStdTestRootCmd(t)
+		cmd.SetArgs([]string{"install", sdkVersion})
+		require.NoError(t, cmd.Execute())
+
+		// verify
+		assertSdkVersion(t, sdkVersion)
+		testMeepyComponent(t)
+		t.Run("link assistant", verifyLink)
+	}
+
+	t.Run("publishes new and legacy annotation", func(t *testing.T) {
+		_, reg := testutil.StartRegistry(t)
+
+		doTest(t)
+
+		r, err := testutil.GetRemote(reg).Repo("components/meep")
+		require.NoError(t, err)
+
+		index, _, err := ociindex.FetchIndexFromTarget(t.Context(), r, "", "1.2.3")
+		require.NoError(t, err)
+
+		expectedVersionAnnotations := []string{ociconsts.LegacyVersionAnnotation, v1.AnnotationVersion}
+		expectedNameAnnotations := []string{ociconsts.DescriptorNameAnnotation, ociconsts.LegacyNameAnnotation}
+		assertAnnotations(t, index.Annotations, expectedVersionAnnotations...)
+		assertAnnotations(t, index.Annotations, expectedNameAnnotations...)
+		assertAnnotations(t, index.Manifests[0].Annotations, expectedVersionAnnotations...)
+		assertAnnotations(t, index.Manifests[0].Annotations, expectedNameAnnotations...)
+	})
+
+	t.Run("missing legacy on the read side is ok", func(t *testing.T) {
+		
+	})
 }
 
 func (suite *RepoSuite) TestPromoteComponents() {

--- a/cmd/dpm/cmd/repo_test.go
+++ b/cmd/dpm/cmd/repo_test.go
@@ -216,7 +216,7 @@ func (suite *RepoSuite) TestOciAnnotations() {
 	t := suite.T()
 
 	sdkVersion := "0.0.1-whatever"
-	expectedTopLevelAnnotation := []string{ociconsts.DescriptorNameAnnotation, v1.AnnotationVersion}
+	expectedTopLevelAnnotation := []string{v1.AnnotationTitle, v1.AnnotationVersion}
 	expectedLegacyTopLevelAnnotation := []string{ociconsts.LegacyNameAnnotation, ociconsts.LegacyVersionAnnotation}
 	expectedFileAnnotation := []string{fileinfo.FileModeAnnotation, fileinfo.FileNameAnnotation, fileinfo.ModTimeAnnotation}
 	expectedLegacyFileAnnotation := []string{fileinfo.LegacyFileModeAnnotation, fileinfo.LegacyFileNameAnnotation, fileinfo.LegacyModTimeAnnotation}

--- a/cmd/dpm/cmd/repo_test.go
+++ b/cmd/dpm/cmd/repo_test.go
@@ -216,7 +216,7 @@ func (suite *RepoSuite) TestOciAnnotations() {
 	t := suite.T()
 
 	sdkVersion := "0.0.1-whatever"
-	expectedTopLevelAnnotation := []string{v1.AnnotationTitle, v1.AnnotationVersion}
+	expectedTopLevelAnnotation := []string{ociconsts.DescriptorNameAnnotation, v1.AnnotationVersion}
 	expectedLegacyTopLevelAnnotation := []string{ociconsts.LegacyNameAnnotation, ociconsts.LegacyVersionAnnotation}
 	expectedFileAnnotation := []string{fileinfo.FileModeAnnotation, fileinfo.FileNameAnnotation, fileinfo.ModTimeAnnotation}
 	expectedLegacyFileAnnotation := []string{fileinfo.LegacyFileModeAnnotation, fileinfo.LegacyFileNameAnnotation, fileinfo.LegacyModTimeAnnotation}

--- a/cmd/dpm/cmd/repo_test.go
+++ b/cmd/dpm/cmd/repo_test.go
@@ -4,8 +4,11 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,11 +24,14 @@ import (
 	"daml.com/x/assistant/pkg/ocilister"
 	"daml.com/x/assistant/pkg/sdkmanifest"
 	"daml.com/x/assistant/pkg/testutil"
+	"daml.com/x/assistant/pkg/utils/fileinfo"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/registry/remote"
 )
 
 type RepoSuite struct {
@@ -206,39 +212,51 @@ func (suite *RepoSuite) TestResolveLatest() {
 	}
 }
 
-func (suite *RepoSuite) TestLegacyOciAnnotation() {
+func (suite *RepoSuite) TestOciAnnotations() {
 	t := suite.T()
-	const sdkVersion = "0.0.1-whatever"
 
-	//fetchManifest := func(t *testing.T, ref string) map[string]any {
-	//	ctx := t.Context()
-	//	repo, err := remote.NewRepository(ref)
-	//	require.NoError(t, err)
-	//
-	//	desc, err := repo.Resolve(t.Context(), "")
-	//	require.NoError(t, err)
-	//
-	//	// Fetch manifest content
-	//	rc, err := repo.Fetch(ctx, desc)
-	//	require.NoError(t, err)
-	//	defer rc.Close()
-	//
-	//	bytes, err := io.ReadAll(rc)
-	//	require.NoError(t, err)
-	//
-	//	var m map[string]any
-	//	require.NoError(t, json.Unmarshal(bytes, m))
-	//
-	//	return
-	//}
+	sdkVersion := "0.0.1-whatever"
+	expectedTopLevelAnnotation := []string{ociconsts.DescriptorNameAnnotation, v1.AnnotationVersion}
+	expectedLegacyTopLevelAnnotation := []string{ociconsts.LegacyNameAnnotation, ociconsts.LegacyVersionAnnotation}
+	expectedFileAnnotation := []string{fileinfo.FileModeAnnotation, fileinfo.FileNameAnnotation, fileinfo.ModTimeAnnotation}
+	expectedLegacyFileAnnotation := []string{fileinfo.LegacyFileModeAnnotation, fileinfo.LegacyFileNameAnnotation, fileinfo.LegacyModTimeAnnotation}
 
-	assertAnnotations := func(t *testing.T, annotations map[string]string, expectedAnnotations ...string) {
+	type LegacyOption int
+	const (
+		IncludesLegacy = iota
+		NoLegacy
+	)
+
+	assertContainsAnnotations := func(t *testing.T, annotations map[string]string, expectedAnnotations ...string) {
 		for _, a := range expectedAnnotations {
 			assert.Contains(t, annotations, a)
 		}
 	}
+	assertNotContainsAnnotations := func(t *testing.T, annotations map[string]string, expectedAnnotations ...string) {
+		for _, a := range expectedAnnotations {
+			assert.NotContains(t, annotations, a)
+		}
+	}
 
-	doTest := func(t *testing.T) {
+	assertTopLevelAnnotation := func(t *testing.T, annotations map[string]string, legacyOption LegacyOption) {
+		assertContainsAnnotations(t, annotations, expectedTopLevelAnnotation...)
+		if legacyOption == IncludesLegacy {
+			assertContainsAnnotations(t, annotations, expectedLegacyTopLevelAnnotation...)
+		} else {
+			assertNotContainsAnnotations(t, annotations, expectedLegacyTopLevelAnnotation...)
+		}
+	}
+
+	assertFileAnnotations := func(t *testing.T, annotations map[string]string, legacyOption LegacyOption) {
+		assertContainsAnnotations(t, annotations, expectedFileAnnotation...)
+		if legacyOption == IncludesLegacy {
+			assertContainsAnnotations(t, annotations, expectedLegacyFileAnnotation...)
+		} else {
+			assertNotContainsAnnotations(t, annotations, expectedLegacyFileAnnotation...)
+		}
+	}
+
+	testPushAndPull := func(t *testing.T) {
 		tmpDpmHome := t.TempDir()
 		t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDpmHome)
 
@@ -262,27 +280,59 @@ func (suite *RepoSuite) TestLegacyOciAnnotation() {
 		t.Run("link assistant", verifyLink)
 	}
 
-	t.Run("publishes new and legacy annotation", func(t *testing.T) {
+	testIndexManifest := func(t *testing.T, repo *remote.Repository, tag string, legacyOption LegacyOption) {
+		index, _, err := ociindex.FetchIndexFromTarget(t.Context(), repo, repo.Reference.Repository, tag)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, index.Manifests)
+		assertTopLevelAnnotation(t, index.Annotations, legacyOption)
+		for _, m := range index.Manifests {
+			assertTopLevelAnnotation(t, m.Annotations, legacyOption)
+		}
+	}
+
+	assertAllAnnotation := func(t *testing.T, registry *httptest.Server, legacyOption LegacyOption) {
+		meepRepo, err := testutil.GetRemote(registry).Repo("components/meep")
+		require.NoError(t, err)
+
+		sdkRepo, err := testutil.GetRemote(registry).Repo("sdk-manifests/open-source")
+		require.NoError(t, err)
+
+		t.Run("component index manifest", func(t *testing.T) {
+			testIndexManifest(t, meepRepo, "1.2.3", legacyOption)
+		})
+
+		t.Run("sdk-manifest index manifest", func(t *testing.T) {
+			testIndexManifest(t, sdkRepo, sdkVersion, legacyOption)
+		})
+
+		t.Run("component image manifests", func(t *testing.T) {
+			index, _, err := ociindex.FetchIndexFromTarget(t.Context(), meepRepo, meepRepo.Reference.Repository, "1.2.3")
+			require.NoError(t, err)
+
+			for _, m := range index.Manifests {
+				image, _, err := FetchImageManifest(t.Context(), meepRepo, meepRepo.Reference.Repository, m.Digest.String())
+				require.NoError(t, err)
+				assertTopLevelAnnotation(t, image.Annotations, legacyOption)
+				for _, layer := range image.Layers {
+					assertFileAnnotations(t, layer.Annotations, legacyOption)
+				}
+			}
+		})
+	}
+
+	t.Run("publishing of new and legacy annotations", func(t *testing.T) {
 		_, reg := testutil.StartRegistry(t)
-
-		doTest(t)
-
-		r, err := testutil.GetRemote(reg).Repo("components/meep")
-		require.NoError(t, err)
-
-		index, _, err := ociindex.FetchIndexFromTarget(t.Context(), r, "", "1.2.3")
-		require.NoError(t, err)
-
-		expectedVersionAnnotations := []string{ociconsts.LegacyVersionAnnotation, v1.AnnotationVersion}
-		expectedNameAnnotations := []string{ociconsts.DescriptorNameAnnotation, ociconsts.LegacyNameAnnotation}
-		assertAnnotations(t, index.Annotations, expectedVersionAnnotations...)
-		assertAnnotations(t, index.Annotations, expectedNameAnnotations...)
-		assertAnnotations(t, index.Manifests[0].Annotations, expectedVersionAnnotations...)
-		assertAnnotations(t, index.Manifests[0].Annotations, expectedNameAnnotations...)
+		testPushAndPull(t)
+		assertAllAnnotation(t, reg, IncludesLegacy)
 	})
 
 	t.Run("missing legacy on the read side is ok", func(t *testing.T) {
-		
+		t.Setenv(ociconsts.SkipLegacyOciAnnotationsEnvVar, "true")
+
+		_, reg := testutil.StartRegistry(t)
+		testPushAndPull(t)
+		assertAllAnnotation(t, reg, NoLegacy)
 	})
 }
 
@@ -489,4 +539,21 @@ func verifyLnkAtPath(t *testing.T, path string) {
 	output, err := io.ReadAll(r)
 	assert.NoError(t, err)
 	assert.Contains(t, string(output), "fake assistant, Ha!")
+}
+
+func FetchImageManifest(ctx context.Context, repo oras.ReadOnlyTarget, repoName, tag string) (*v1.Manifest, []byte, error) {
+	desc, bytes, err := oras.FetchBytes(ctx, repo, tag, oras.DefaultFetchBytesOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if desc.MediaType != v1.MediaTypeImageManifest {
+		return nil, nil, fmt.Errorf("reference \"%s:%s\" is %q and not an image manifest", repoName, tag, desc.MediaType)
+	}
+
+	v := v1.Manifest{}
+	if err := json.Unmarshal(bytes, &v); err != nil {
+		return nil, nil, err
+	}
+	return &v, bytes, nil
 }

--- a/pkg/darpuller/darpuller.go
+++ b/pkg/darpuller/darpuller.go
@@ -1,7 +1,6 @@
 package darpuller
 
 import (
-	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -114,12 +113,8 @@ func (a *OciDarPuller) getVersion(ctx context.Context, repo oras.ReadOnlyTarget,
 		return nil, err
 	}
 
-	v := cmp.Or(
-		annotations[v1.AnnotationVersion],
-		// fallback
-		annotations[ociconsts.DescriptorVersionAnnotation],
-	)
-	if v == "" {
+	v, ok := utils.GetWithFallback(annotations, v1.AnnotationVersion, ociconsts.LegacyVersionAnnotation)
+	if !ok {
 		return nil, fmt.Errorf("missing version annotation in image manifest")
 	}
 	ver, err := semver.StrictNewVersion(v)

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -33,7 +33,8 @@ const (
 	LegacyNameAnnotation      = LegacyDpmAnnotationPrefix + "name"
 	LegacyVersionAnnotation   = LegacyDpmAnnotationPrefix + "version"
 
-	DpmAnnotationPrefix = "com.dpm."
+	DpmAnnotationPrefix      = "com.dpm."
+	DescriptorNameAnnotation = DpmAnnotationPrefix + "name"
 
 	// SkipLegacyOciAnnotationsEnvVar will skip attaching legacy annotations when publishing oci manifests
 	SkipLegacyOciAnnotationsEnvVar = "SKIP_LEGACY_OCI_ANNOTATIONS"
@@ -47,7 +48,7 @@ type DescriptorAnnotations struct {
 }
 
 func (d DescriptorAnnotations) AppendToMap(annotations map[string]string) {
-	annotations[v1.AnnotationTitle] = d.Name
+	annotations[DescriptorNameAnnotation] = d.Name
 	annotations[v1.AnnotationVersion] = d.Version.String()
 
 	// deprecated but keeping for backwards compatibility with older dpm binaries

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -5,6 +5,7 @@ package oci
 
 import (
 	"fmt"
+	"os"
 
 	"daml.com/x/assistant/pkg/utils"
 	"github.com/Masterminds/semver/v3"
@@ -34,6 +35,9 @@ const (
 
 	DpmAnnotationPrefix      = "com.dpm."
 	DescriptorNameAnnotation = DpmAnnotationPrefix + "name"
+
+	// SkipLegacyOciAnnotationsEnvVar will skip attaching legacy annotations when publishing oci manifests
+	SkipLegacyOciAnnotationsEnvVar = "SKIP_LEGACY_OCI_ANNOTATIONS"
 )
 
 // DescriptorAnnotations are required annotations to be appended onto image and index manifests.
@@ -48,8 +52,10 @@ func (d DescriptorAnnotations) AppendToMap(annotations map[string]string) {
 	annotations[v1.AnnotationVersion] = d.Version.String()
 
 	// deprecated but keeping for backwards compatibility with older dpm binaries
-	annotations[LegacyNameAnnotation] = d.Name
-	annotations[LegacyVersionAnnotation] = d.Version.String()
+	if os.Getenv(SkipLegacyOciAnnotationsEnvVar) != "true" {
+		annotations[LegacyNameAnnotation] = d.Name
+		annotations[LegacyVersionAnnotation] = d.Version.String()
+	}
 }
 
 func LegacyDpmAnnotation(annotation string) string {

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -33,7 +33,7 @@ const (
 	LegacyNameAnnotation      = LegacyDpmAnnotationPrefix + "name"
 	LegacyVersionAnnotation   = LegacyDpmAnnotationPrefix + "version"
 
-	DpmAnnotationPrefix      = "com.dpm."
+	DpmAnnotationPrefix      = "network.canton.dpm."
 	DescriptorNameAnnotation = DpmAnnotationPrefix + "name"
 
 	// SkipLegacyOciAnnotationsEnvVar will skip attaching legacy annotations when publishing oci manifests

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -33,8 +33,7 @@ const (
 	LegacyNameAnnotation      = LegacyDpmAnnotationPrefix + "name"
 	LegacyVersionAnnotation   = LegacyDpmAnnotationPrefix + "version"
 
-	DpmAnnotationPrefix      = "com.dpm."
-	DescriptorNameAnnotation = DpmAnnotationPrefix + "name"
+	DpmAnnotationPrefix = "com.dpm."
 
 	// SkipLegacyOciAnnotationsEnvVar will skip attaching legacy annotations when publishing oci manifests
 	SkipLegacyOciAnnotationsEnvVar = "SKIP_LEGACY_OCI_ANNOTATIONS"
@@ -48,7 +47,7 @@ type DescriptorAnnotations struct {
 }
 
 func (d DescriptorAnnotations) AppendToMap(annotations map[string]string) {
-	annotations[DescriptorNameAnnotation] = d.Name
+	annotations[v1.AnnotationTitle] = d.Name
 	annotations[v1.AnnotationVersion] = d.Version.String()
 
 	// deprecated but keeping for backwards compatibility with older dpm binaries

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -6,7 +6,9 @@ package oci
 import (
 	"fmt"
 
+	"daml.com/x/assistant/pkg/utils"
 	"github.com/Masterminds/semver/v3"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const (
@@ -25,9 +27,13 @@ const (
 	SdkManifestsEnterpriseRepo = sdkManifestsRepoPrefix + "enterprise"
 	SdkManifestsPrivateRepo    = sdkManifestsRepoPrefix + "private"
 
-	DAAnnotationPrefix          = "com.digitalasset."
-	DescriptorNameAnnotation    = DAAnnotationPrefix + "name"
-	DescriptorVersionAnnotation = DAAnnotationPrefix + "version"
+	// deprecated annotations
+	LegacyDpmAnnotationPrefix = "com.digitalasset."
+	LegacyNameAnnotation      = LegacyDpmAnnotationPrefix + "name"
+	LegacyVersionAnnotation   = LegacyDpmAnnotationPrefix + "version"
+
+	DpmAnnotationPrefix      = "com.dpm."
+	DescriptorNameAnnotation = DpmAnnotationPrefix + "name"
 )
 
 // DescriptorAnnotations are required annotations to be appended onto image and index manifests.
@@ -39,19 +45,28 @@ type DescriptorAnnotations struct {
 
 func (d DescriptorAnnotations) AppendToMap(annotations map[string]string) {
 	annotations[DescriptorNameAnnotation] = d.Name
-	annotations[DescriptorVersionAnnotation] = d.Version.String()
+	annotations[v1.AnnotationVersion] = d.Version.String()
+
+	// deprecated but keeping for backwards compatibility with older dpm binaries
+	annotations[LegacyNameAnnotation] = d.Name
+	annotations[LegacyVersionAnnotation] = d.Version.String()
 }
 
-func DAAnnotation(annotation string) string {
-	return DAAnnotationPrefix + annotation
+func LegacyDpmAnnotation(annotation string) string {
+	return LegacyDpmAnnotationPrefix + annotation
+}
+
+func DpmAnnotation(annotation string) string {
+	return DpmAnnotationPrefix + annotation
 }
 
 func VersionFromDescriptorAnnotations(descriptorAnnotations map[string]string) (*semver.Version, error) {
-	err := fmt.Errorf("descriptor missing required %q annotations", DescriptorVersionAnnotation)
+	err := fmt.Errorf("descriptor missing required (%q, or %q) annotations", v1.AnnotationVersion, LegacyVersionAnnotation)
 	if descriptorAnnotations == nil {
 		return nil, err
 	}
-	version, ok := descriptorAnnotations[DescriptorVersionAnnotation]
+
+	version, ok := utils.GetWithFallback(descriptorAnnotations, v1.AnnotationVersion, LegacyVersionAnnotation)
 	if !ok {
 		return nil, err
 	}

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -12,13 +12,12 @@ import (
 	"strings"
 	"testing"
 
-	"daml.com/x/assistant/pkg/ocipusher/sdkmanifestpusher"
-
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/assistantconfig/assistantremote"
 	ociconsts "daml.com/x/assistant/pkg/oci"
 	"daml.com/x/assistant/pkg/ociindex"
 	"daml.com/x/assistant/pkg/ocipusher"
+	"daml.com/x/assistant/pkg/ocipusher/sdkmanifestpusher"
 	"daml.com/x/assistant/pkg/sdkmanifest"
 	"daml.com/x/assistant/pkg/simpleplatform"
 	"daml.com/x/assistant/pkg/utils"

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -42,7 +42,7 @@ func TestdataPath(t *testing.T, path ...string) string {
 }
 
 func PushComponentUri(registry *httptest.Server, name, repo, tag, pathToComponent string, extraTags ...string) (args []string) {
-	uri := fmt.Sprintf("%s/%s", getRemote(registry).Registry, repo)
+	uri := fmt.Sprintf("%s/%s", GetRemote(registry).Registry, repo)
 
 	args = []string{"repo", "push-component", name, tag, "--registry", uri, "-p", "generic=" + pathToComponent}
 
@@ -57,7 +57,7 @@ func PushComponentUri(registry *httptest.Server, name, repo, tag, pathToComponen
 }
 
 func PushComponent(t *testing.T, ctx context.Context, registry *httptest.Server, componentName, tag, pathToComponent string, extraTags ...string) {
-	r := getRemote(registry)
+	r := GetRemote(registry)
 	v, err := semver.NewVersion(tag)
 	require.NoError(t, err)
 	requiredAnnotations := ociconsts.DescriptorAnnotations{
@@ -94,7 +94,7 @@ func PushComponent(t *testing.T, ctx context.Context, registry *httptest.Server,
 }
 
 func PushDar(t *testing.T, ctx context.Context, registry *httptest.Server, darName, tag, pathToComponent string) {
-	r := getRemote(registry)
+	r := GetRemote(registry)
 	v, err := semver.NewVersion(tag)
 	require.NoError(t, err)
 	requiredAnnotations := ociconsts.DescriptorAnnotations{
@@ -134,7 +134,7 @@ func PushAssembly(t *testing.T, ctx context.Context, edition sdkmanifest.Edition
 		"darwin/arm64",
 	}
 
-	r := getRemote(registry)
+	r := GetRemote(registry)
 	v, err := semver.NewVersion(tag)
 	require.NoError(t, err)
 	manifests := lo.SliceToMap(platforms, func(p string) (simpleplatform.NonGeneric, string) {
@@ -154,7 +154,7 @@ func PushAssembly(t *testing.T, ctx context.Context, edition sdkmanifest.Edition
 	require.NoError(t, err)
 }
 
-func getRemote(registry *httptest.Server) *assistantremote.Remote {
+func GetRemote(registry *httptest.Server) *assistantremote.Remote {
 	prefix := "http://"
 	insecure := strings.HasPrefix(registry.URL, prefix)
 	if !insecure {
@@ -172,7 +172,7 @@ func StartRegistry(t *testing.T) (client *assistantremote.Remote, reg *httptest.
 	t.Setenv(assistantconfig.RegistryAuthConfigPathEnvVar, TestdataPath(t, "empty-docker-config.json"))
 	t.Setenv(assistantconfig.AllowInsecureRegistryEnvVar, "true")
 
-	return getRemote(reg), reg
+	return GetRemote(reg), reg
 }
 
 type CommonSetupSuite struct {

--- a/pkg/utils/fileinfo/fileinfo.go
+++ b/pkg/utils/fileinfo/fileinfo.go
@@ -5,6 +5,7 @@ package fileinfo
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -39,15 +40,22 @@ func (fi *FileInfo) AsAnnotations() map[string]string {
 	modTime := fi.ModTime.Format(time.RFC3339)
 	fileName := fi.FileName
 
-	return map[string]string{
+	m := map[string]string{
 		FileModeAnnotation: mode,
 		ModTimeAnnotation:  modTime,
 		FileNameAnnotation: fileName,
-
-		LegacyFileModeAnnotation: mode,
-		LegacyModTimeAnnotation:  modTime,
-		LegacyFileNameAnnotation: fileName,
 	}
+
+	if os.Getenv(ociconsts.SkipLegacyOciAnnotationsEnvVar) != "true" {
+		legacy := map[string]string{
+			LegacyFileModeAnnotation: mode,
+			LegacyModTimeAnnotation:  modTime,
+			LegacyFileNameAnnotation: fileName,
+		}
+		maps.Copy(m, legacy)
+	}
+
+	return m
 }
 
 // Apply sets the fileinfo for the corresponding file on the filesystem

--- a/pkg/utils/fileinfo/fileinfo.go
+++ b/pkg/utils/fileinfo/fileinfo.go
@@ -11,16 +11,21 @@ import (
 	"time"
 
 	ociconsts "daml.com/x/assistant/pkg/oci"
+	"daml.com/x/assistant/pkg/utils"
 )
 
 var (
-	FileModeAnnotation = ociconsts.DAAnnotation("file-mode")
-	ModTimeAnnotation  = ociconsts.DAAnnotation("file-modtime")
-	FileNameAnnotation = ociconsts.DAAnnotation("file-name")
+	LegacyFileModeAnnotation = ociconsts.LegacyDpmAnnotation("file-mode")
+	LegacyModTimeAnnotation  = ociconsts.LegacyDpmAnnotation("file-modtime")
+	LegacyFileNameAnnotation = ociconsts.LegacyDpmAnnotation("file-name")
+
+	FileModeAnnotation = ociconsts.DpmAnnotation("file-mode")
+	ModTimeAnnotation  = ociconsts.DpmAnnotation("file-modtime")
+	FileNameAnnotation = ociconsts.DpmAnnotation("file-name")
 )
 
-func missingAnnotation(a string) error {
-	return fmt.Errorf("missing %s annotation", a)
+func missingAnnotations(a, b string) error {
+	return fmt.Errorf("missing (%q, or %q) annotation", a, b)
 }
 
 type FileInfo struct {
@@ -30,10 +35,18 @@ type FileInfo struct {
 }
 
 func (fi *FileInfo) AsAnnotations() map[string]string {
+	mode := fmt.Sprintf("%o", fi.FileMode)
+	modTime := fi.ModTime.Format(time.RFC3339)
+	fileName := fi.FileName
+
 	return map[string]string{
-		FileModeAnnotation: fmt.Sprintf("%o", fi.FileMode),
-		ModTimeAnnotation:  fi.ModTime.Format(time.RFC3339),
-		FileNameAnnotation: fi.FileName,
+		FileModeAnnotation: mode,
+		ModTimeAnnotation:  modTime,
+		FileNameAnnotation: fileName,
+
+		LegacyFileModeAnnotation: mode,
+		LegacyModTimeAnnotation:  modTime,
+		LegacyFileNameAnnotation: fileName,
 	}
 }
 
@@ -51,27 +64,27 @@ func NewFromAnnotations(annotations map[string]string) (*FileInfo, error) {
 		return nil, fmt.Errorf("missing fileinfo annotations")
 	}
 
-	fileModeStr, ok := annotations[FileModeAnnotation]
+	fileModeStr, ok := utils.GetWithFallback(annotations, FileModeAnnotation, LegacyFileModeAnnotation)
 	if !ok {
-		return nil, missingAnnotation(FileModeAnnotation)
+		return nil, missingAnnotations(FileModeAnnotation, LegacyFileModeAnnotation)
 	}
 	fileMode, err := strconv.ParseUint(fileModeStr, 8, 32)
 	if err != nil {
 		return nil, err
 	}
 
-	modTimeStr, ok := annotations[ModTimeAnnotation]
+	modTimeStr, ok := utils.GetWithFallback(annotations, ModTimeAnnotation, LegacyModTimeAnnotation)
 	if !ok {
-		return nil, missingAnnotation(FileModeAnnotation)
+		return nil, missingAnnotations(ModTimeAnnotation, LegacyModTimeAnnotation)
 	}
 	modTime, err := time.Parse(time.RFC3339, modTimeStr)
 	if err != nil {
 		return nil, err
 	}
 
-	fileName, ok := annotations[FileNameAnnotation]
+	fileName, ok := utils.GetWithFallback(annotations, FileNameAnnotation, LegacyFileNameAnnotation)
 	if !ok {
-		return nil, missingAnnotation(FileNameAnnotation)
+		return nil, missingAnnotations(FileNameAnnotation, LegacyFileNameAnnotation)
 	}
 
 	return &FileInfo{

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -29,3 +29,13 @@ var envVarRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 func IsValidEnvVarIdentifier(key string) bool {
 	return envVarRegex.MatchString(key)
 }
+
+func GetWithFallback(m map[string]string, primary, fallback string) (string, bool) {
+	if val, ok := m[primary]; ok {
+		return val, true
+	}
+	if val, ok := m[fallback]; ok {
+		return val, true
+	}
+	return "", false
+}


### PR DESCRIPTION
- using the standard oci annotation `org.opencontainers.image.version` for component version instead of a custom one
- rename the custom annotation to use `com.dpm.` as prefix instead of `com.digitalasset.`, but keep the old ones for backward compat

I [wanted to use](https://github.com/digital-asset/dpm/pull/139/changes/7fcbcb5a7c65ad8505a966baefc71217efc3c053) the `com.opencontainer.image.title` annotation for the component name, but that's causing a bug due to our usage of `oras-go`'s Store when pushing, and we'd have to figure that out