### PR TITLE
clearer error messages

### DIFF
--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -306,7 +306,7 @@ func (a *Assembler) collectComponents(ctx context.Context, assemblyManifest *sdk
 	for _, comp := range assemblyManifest.Spec.Components {
 		resolved, err := a.collectComponent(ctx, assemblyManifest.AbsolutePath, comp)
 		if err != nil {
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("error handling component %q in %q: %w", comp.Name, assemblyManifest.AbsolutePath, err))
 			continue
 		}
 		result[comp.Name] = resolved
@@ -366,14 +366,12 @@ func (a *Assembler) handleURI(ctx context.Context, comp *sdkmanifest.Component) 
 		return "", err
 	}
 
-	componentPath := ref.Repository
-
-	tag, err := semver.StrictNewVersion(ref.Reference)
+	version, err := semver.StrictNewVersion(ref.Reference)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to parse %q as strict semantic version in %q: %w", ref.Reference, *comp.Uri, err)
 	}
 
-	destPath := a.ociComponentPath(comp.Name, tag.String())
+	destPath := a.ociComponentPath(comp.Name, version.String())
 
 	// check if component is already in the cache
 	ok, err := utils.DirExists(destPath)
@@ -398,7 +396,7 @@ func (a *Assembler) handleURI(ctx context.Context, comp *sdkmanifest.Component) 
 		// Passing in old config layoutCache
 		customPuller := remotepuller.New(a.config.OciLayoutCache, customRemote)
 
-		if err := customPuller.PullComponentByFullPath(ctx, componentPath, tag.String(), destPath, platform); err != nil {
+		if err := customPuller.PullComponentByFullPath(ctx, ref.Repository, version.String(), destPath, platform); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/sdkmanifest/spec.go
+++ b/pkg/sdkmanifest/spec.go
@@ -62,8 +62,14 @@ func (s *Spec) UnmarshalYAML(bytes []byte) error {
 }
 
 type Component struct {
-	Name      string  `yaml:"-"`
-	Version   *SemVer `yaml:"version,omitempty"`
+	Name    string  `yaml:"-"`
+	Version *SemVer `yaml:"version,omitempty"`
+
+	// We don't yet have support for floaty or arbitrary tags (as that requires lockfiles),
+	// but the `dpm resolve-tags` command used in the assembly process for putting together
+	// and publishing SDKs uses this same schema and allows floaty ImageTag
+	//
+	// Consider creating a separate struct for use by SDK assembly commands
 	ImageTag  *string `yaml:"image-tag,omitempty"`
 	LocalPath *string `yaml:"local-path,omitempty"`
 	Uri       *string `yaml:"uri,omitempty"`


### PR DESCRIPTION
```
go run ../cmd/dpm/main.go --help

error handling component "foo" in "/Users/sammyabed/dpm/foo/daml.yaml": failed to parse "main" as strict semantic version in "europe-docker.pkg.dev/da-images/public-unstable/components/damlc:main": invalid semantic version
```