### PR TITLE
Collapse flags into single arg

### DIFF
--- a/cmd/dpm/cmd/artifacts_test.go
+++ b/cmd/dpm/cmd/artifacts_test.go
@@ -28,10 +28,10 @@ func (suite *RepoSuite) TestPublishDar() {
 
 	cmd := createStdTestRootCmd(t)
 	args := []string{
-		"publish", "dar", "--name", "meep", "--version", "1.2.3",
+		"publish", "dar", fmt.Sprintf("oci://%s/meep:1.2.3", destinationRegistry),
 		"-f", testutil.TestdataPath(t, "test-dar"),
-		"--registry", "oci://" + destinationRegistry,
 	}
+
 	if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
 		args = append(args, "--insecure")
 	}
@@ -44,12 +44,11 @@ func (suite *RepoSuite) TestPublishThirdPartyComponents() {
 	_, _ = testutil.StartRegistry(t)
 	uri := fmt.Sprintf("%s/x/y/z", os.Getenv(assistantconfig.OciRegistryEnvVar))
 
-	args := []string{"publish", "component", "--name", "meep", "--version", "1.2.3",
+	args := []string{"publish", "component", fmt.Sprintf("oci://%s/meep:1.2.3", uri),
 		"-p", "windows/amd64=" + testutil.TestdataPath(t, "meepy-component", "windows"),
 		"-p", "linux/amd64=" + testutil.TestdataPath(t, "meepy-component", "unix"),
 		"-p", "darwin/amd64=" + testutil.TestdataPath(t, "meepy-component", "unix"),
 		"-p", "darwin/arm64=" + testutil.TestdataPath(t, "meepy-component", "unix"),
-		"--registry", "oci://" + uri,
 	}
 
 	if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
@@ -63,33 +62,34 @@ func (suite *RepoSuite) TestComponentTags() {
 	t := suite.T()
 	_, reg := testutil.StartRegistry(t)
 
-	args := testutil.PushComponentUri(reg, "meep", "bar/foo", "1.2.3", testutil.TestdataPath(t, "meepy-component", testutil.OS))
+	args := testutil.PushComponentUri(reg, fmt.Sprintf("%s/%s:%s", "foo/bar", "meep", "1.2.3"), testutil.TestdataPath(t, "meepy-component", testutil.OS))
 	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
 
-	args = testutil.PushComponentUri(reg, "meep", "foo/bar", "1.2.4", testutil.TestdataPath(t, "meepy-component", testutil.OS))
+	args = testutil.PushComponentUri(reg, fmt.Sprintf("%s/%s:%s", "bar/foo", "meep", "1.2.4"), testutil.TestdataPath(t, "meepy-component", testutil.OS))
 	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
 
 	t.Run("test tags for arbitrary repo", func(t *testing.T) {
 		res := listArtifactTags(t, "oci://"+strings.TrimPrefix(reg.URL, "http://")+"/foo/bar/meep")
-		expected := []string{"1.2.4", "1.2.4.generic"}
+		expected := []string{"1.2.3", "1.2.3.generic"}
 		assert.Equal(t, expected, res)
 	})
 
 	t.Run("test tags for arbitrary repo", func(t *testing.T) {
 		res := listArtifactTags(t, "oci://"+strings.TrimPrefix(reg.URL, "http://")+"/bar/foo/meep")
-		expected := []string{"1.2.3", "1.2.3.generic"}
+		expected := []string{"1.2.4", "1.2.4.generic"}
 		assert.Equal(t, expected, res)
 	})
 }
+
 func (suite *RepoSuite) TestDarTags() {
 	t := suite.T()
 	t.Setenv(assistantconfig.DpmLockfileEnabledEnvVar, "true")
 	_, reg := testutil.StartRegistry(t)
 
-	args := testutil.PushDarUri(reg, "meep", "foo/bar", "1.2.3", testutil.TestdataPath(t, "test-dar"))
+	args := testutil.PushDarUri(reg, fmt.Sprintf("%s/%s:%s", "foo/bar", "meep", "1.2.3"), testutil.TestdataPath(t, "test-dar"))
 	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
 
-	args = testutil.PushDarUri(reg, "meep", "bar/foo", "1.2.4", testutil.TestdataPath(t, "test-dar"))
+	args = testutil.PushDarUri(reg, fmt.Sprintf("%s/%s:%s", "bar/foo", "meep", "1.2.4"), testutil.TestdataPath(t, "test-dar"))
 	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
 
 	t.Run("test tags for arbitrary repo", func(t *testing.T) {

--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -425,7 +426,7 @@ func (suite *MainSuite) TestComponentPublishDryRun() {
 	})
 
 	t.Run("third party", func(t *testing.T) {
-		args := []string{"--dry-run", "--registry", "oci://foo.example.com/a/b", "--name", "meep", "--version", "1.2.3-meep", "-p", "generic=" + testutil.TestdataPath(t, "meepy-component", testutil.OS)}
+		args := []string{"--dry-run", "oci://foo.example.com/a/b/meep:1.2.3-meep", "-p", "generic=" + testutil.TestdataPath(t, "meepy-component", testutil.OS)}
 		doTest(t, "foo.example.com/a/b/meep", []string{"publish", "component"}, args)
 	})
 }
@@ -936,11 +937,9 @@ func (suite *MainSuite) TestInstallPackageMultiRegistry() {
 	require.NoError(t, err)
 
 	t.Cleanup(func() { require.NoError(t, os.Chdir(cwd)) })
-
-	args := testutil.PushComponentUri(reg, "meep", "foo/bar", "1.2.3", testutil.TestdataPath(t, "meepy-component", testutil.OS))
+	args := testutil.PushComponentUri(reg, fmt.Sprintf("%s/%s:%s", "foo/bar", "meep", "1.2.3"), testutil.TestdataPath(t, "meepy-component", testutil.OS))
 	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
-
-	args = testutil.PushComponentUri(altReg, "rando", "bar/foo", "1.2.4", testutil.TestdataPath(t, "components", "rando"))
+	args = testutil.PushComponentUri(altReg, fmt.Sprintf("%s/%s:%s", "bar/foo", "rando", "1.2.4"), testutil.TestdataPath(t, "components", "rando"))
 	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
 
 	// Want to ensure that version is still using handleOCI - push up using internal DA pushComponent

--- a/cmd/dpm/cmd/publish/component/component.go
+++ b/cmd/dpm/cmd/publish/component/component.go
@@ -79,10 +79,6 @@ func Cmd() *cobra.Command {
 			return publish.New(publishConfig, cmd).Publish(cmd.Context())
 		},
 	}
-	//cmd.Flags().StringVarP(&c.Name, publishcmd.ComponentNameFlagName, "n", "", "name of component to be pushed")
-	//cmd.MarkFlagRequired(publishcmd.ComponentNameFlagName)
-	//cmd.Flags().StringVarP(&c.Version, publishcmd.VersionFlagName, "v", "", "version of component to be pushed")
-	//cmd.MarkFlagRequired(publishcmd.VersionFlagName)
 
 	cmd.Flags().BoolVarP(&c.DryRun, "dry-run", "d", false, "don't actually push to the registry")
 	cmd.Flags().BoolVarP(&c.IncludeGitInfo, "include-git-info", "g", false, "include git info as annotations on the published manifest")
@@ -92,8 +88,6 @@ func Cmd() *cobra.Command {
 	cmd.MarkFlagRequired(publishcmd.PlatformFlagName)
 
 	cmd.Flags().StringSliceVarP(&c.ExtraTags, "extra-tags", "t", []string{}, "publish extra tags besides the semver")
-
-	//cmd.Flags().StringVar(&c.Registry, "registry", "", "OCI registry to use for pushing")
 
 	cmd.Flags().BoolVar(&c.Insecure, "insecure", false, "use http instead of https for OCI registry")
 	cmd.Flags().StringVar(&c.RegistryAuth, "auth", "", "path to a config file similar to docker’s config.json to use for authenticating to the OCI registry. Defaults to docker's config.json")

--- a/cmd/dpm/cmd/publish/component/component.go
+++ b/cmd/dpm/cmd/publish/component/component.go
@@ -30,7 +30,9 @@ func Cmd() *cobra.Command {
 
 			oci := args[0]
 
-			if !strings.HasPrefix(oci, "oci://") {
+			if strings.HasPrefix(oci, "oci://") {
+				oci = strings.TrimPrefix(oci, "oci://")
+			} else {
 				return fmt.Errorf("invalid oci registry argument, must be formatted as oci uri ie. oci://whatever.dev/bar/test/foo:1.2.3-alpha")
 			}
 

--- a/cmd/dpm/cmd/publish/component/component.go
+++ b/cmd/dpm/cmd/publish/component/component.go
@@ -11,6 +11,7 @@ import (
 	"daml.com/x/assistant/pkg/publish"
 	"daml.com/x/assistant/pkg/publishcmd"
 	"github.com/Masterminds/semver/v3"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/registry"
 )
@@ -20,13 +21,27 @@ func Cmd() *cobra.Command {
 
 	// TODO stop publishing a tag for every platform
 	cmd := &cobra.Command{
-		Use:     "component",
+		Use:     "component registry",
 		Short:   "Publish a component to an OCI registry",
 		Long:    "Will publish the component (OCI index) to <registry>/<name>:<version>",
-		Example: "dpm artifacts publish component --name foo --version 1.2.3-alpha -p linux/amd64=dist/foo-linux -p darwin/arm64=dist/foo-darwin --registry 'oci://whatever.dev/bar/test'",
+		Example: "dpm artifacts publish component 'oci://whatever.dev/bar/test/foo:1.2.3-alpha' -p linux/amd64=dist/foo-linux -p darwin/arm64=dist/foo-darwin ",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			name := c.Name
-			version, err := semver.StrictNewVersion(c.Version)
+
+			oci := args[0]
+
+			if !strings.HasPrefix(oci, "oci://") {
+				return fmt.Errorf("invalid oci registry argument, must be formatted as oci uri ie. oci://whatever.dev/bar/test/foo:1.2.3-alpha")
+			}
+
+			ref, err := registry.ParseReference(oci)
+			if err != nil {
+				return fmt.Errorf("invalid registry formatting: %s", oci)
+			}
+
+			version, err := semver.StrictNewVersion(ref.Reference)
+			name, _ := lo.Last(strings.Split(ref.Repository, "/"))
+
 			if err != nil {
 				return fmt.Errorf("invalid version argument: %w", err)
 			}
@@ -35,12 +50,7 @@ func Cmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if strings.HasPrefix(c.Registry, "oci://") {
-				c.Registry = strings.TrimPrefix(c.Registry, "oci://")
-			} else {
-				return fmt.Errorf("invalid registry argument, must be formatted as oci uri ie. oci://whatever.dev")
-			}
-			ref, err := registry.ParseReference(fmt.Sprintf("%s/%s", strings.TrimRight(c.Registry, "/"), name))
+
 			if err != nil {
 				return err
 			}
@@ -67,10 +77,10 @@ func Cmd() *cobra.Command {
 			return publish.New(publishConfig, cmd).Publish(cmd.Context())
 		},
 	}
-	cmd.Flags().StringVarP(&c.Name, publishcmd.ComponentNameFlagName, "n", "", "name of component to be pushed")
-	cmd.MarkFlagRequired(publishcmd.ComponentNameFlagName)
-	cmd.Flags().StringVarP(&c.Version, publishcmd.VersionFlagName, "v", "", "version of component to be pushed")
-	cmd.MarkFlagRequired(publishcmd.VersionFlagName)
+	//cmd.Flags().StringVarP(&c.Name, publishcmd.ComponentNameFlagName, "n", "", "name of component to be pushed")
+	//cmd.MarkFlagRequired(publishcmd.ComponentNameFlagName)
+	//cmd.Flags().StringVarP(&c.Version, publishcmd.VersionFlagName, "v", "", "version of component to be pushed")
+	//cmd.MarkFlagRequired(publishcmd.VersionFlagName)
 
 	cmd.Flags().BoolVarP(&c.DryRun, "dry-run", "d", false, "don't actually push to the registry")
 	cmd.Flags().BoolVarP(&c.IncludeGitInfo, "include-git-info", "g", false, "include git info as annotations on the published manifest")
@@ -81,8 +91,8 @@ func Cmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&c.ExtraTags, "extra-tags", "t", []string{}, "publish extra tags besides the semver")
 
-	cmd.Flags().StringVar(&c.Registry, "registry", "", "OCI registry to use for pushing")
-	
+	//cmd.Flags().StringVar(&c.Registry, "registry", "", "OCI registry to use for pushing")
+
 	cmd.Flags().BoolVar(&c.Insecure, "insecure", false, "use http instead of https for OCI registry")
 	cmd.Flags().StringVar(&c.RegistryAuth, "auth", "", "path to a config file similar to docker’s config.json to use for authenticating to the OCI registry. Defaults to docker's config.json")
 

--- a/cmd/dpm/cmd/publish/component/component.go
+++ b/cmd/dpm/cmd/publish/component/component.go
@@ -21,7 +21,7 @@ func Cmd() *cobra.Command {
 
 	// TODO stop publishing a tag for every platform
 	cmd := &cobra.Command{
-		Use:     "component registry",
+		Use:     "component <registry>",
 		Short:   "Publish a component to an OCI registry",
 		Long:    "Will publish the component (OCI index) to <registry>/<name>:<version>",
 		Example: "dpm artifacts publish component 'oci://whatever.dev/bar/test/foo:1.2.3-alpha' -p linux/amd64=dist/foo-linux -p darwin/arm64=dist/foo-darwin ",

--- a/cmd/dpm/cmd/publish/dar/dar.go
+++ b/cmd/dpm/cmd/publish/dar/dar.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
+	ociconsts "daml.com/x/assistant/pkg/oci"
+	"daml.com/x/assistant/pkg/publish"
 	"daml.com/x/assistant/pkg/publishcmd"
 	"daml.com/x/assistant/pkg/publishdar"
 	"github.com/Masterminds/semver/v3"
@@ -28,7 +30,9 @@ func Cmd() *cobra.Command {
 
 			oci := args[0]
 
-			if !strings.HasPrefix(oci, "oci://") {
+			if strings.HasPrefix(oci, "oci://") {
+				oci = strings.TrimPrefix(oci, "oci://")
+			} else {
 				return fmt.Errorf("invalid oci registry argument, must be formatted as oci uri ie. oci://whatever.dev/bar/test/foo:1.2.3-alpha")
 			}
 
@@ -40,16 +44,12 @@ func Cmd() *cobra.Command {
 			version, err := semver.StrictNewVersion(ref.Reference)
 			name, _ := lo.Last(strings.Split(ref.Repository, "/"))
 
-			//version, err := semver.StrictNewVersion(c.Version)
-			//if err != nil {
-			//	return fmt.Errorf("invalid version argument: %w", err)
-			//}
-			//
-			//if strings.HasPrefix(c.Registry, "oci://") {
-			//	c.Registry = strings.TrimPrefix(c.Registry, "oci://")
-			//} else {
-			//	return fmt.Errorf("invalid registry argument, must be formatted as oci uri ie. oci://whatever.dev")
-			//}
+			destination := &publish.Destination{
+				Registry: ref.Registry,
+				Artifact: &ociconsts.DarArtifact{
+					DarRepo: ref.Repository,
+				},
+			}
 
 			cmd.SilenceUsage = true
 			publishDarConfig := &publishdar.DarConfig{
@@ -59,7 +59,7 @@ func Cmd() *cobra.Command {
 				DryRun:         c.DryRun,
 				IncludeGitInfo: c.IncludeGitInfo,
 				Annotations:    c.Annotations,
-				Registry:       fmt.Sprintf("%s/%s", ref.Registry, ref.Repository),
+				Destination:    destination,
 				AuthFilePath:   c.RegistryAuth,
 				Insecure:       c.Insecure,
 				ExtraTags:      c.ExtraTags,

--- a/cmd/dpm/cmd/publish/dar/dar.go
+++ b/cmd/dpm/cmd/publish/dar/dar.go
@@ -21,7 +21,7 @@ import (
 func Cmd() *cobra.Command {
 	c := publishcmd.PublishDarCmd{}
 	cmd := &cobra.Command{
-		Use:     "dar registry",
+		Use:     "dar <registry>",
 		Short:   "Publish a dar to an OCI registry",
 		Example: "dpm artifacts publish dar 'oci://whatever.dev/bar/test/foo:1.2.3-alpha' -f path/to/foo.dar",
 		Hidden:  !assistantconfig.DpmLockfileEnabled(), // Use single feature flag to represent features in current release

--- a/cmd/dpm/cmd/publish/dar/dar.go
+++ b/cmd/dpm/cmd/publish/dar/dar.go
@@ -11,37 +11,55 @@ import (
 	"daml.com/x/assistant/pkg/publishcmd"
 	"daml.com/x/assistant/pkg/publishdar"
 	"github.com/Masterminds/semver/v3"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2/registry"
 )
 
 func Cmd() *cobra.Command {
 	c := publishcmd.PublishDarCmd{}
 	cmd := &cobra.Command{
-		Use:     "dar",
+		Use:     "dar registry",
 		Short:   "Publish a dar to an OCI registry",
-		Example: "dpm artifacts publish dar --name foo --version 1.2.3-alpha -f path/to/foo.dar",
+		Example: "dpm artifacts publish dar 'oci://whatever.dev/bar/test/foo:1.2.3-alpha' -f path/to/foo.dar",
 		Hidden:  !assistantconfig.DpmLockfileEnabled(), // Use single feature flag to represent features in current release
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			version, err := semver.StrictNewVersion(c.Version)
-			if err != nil {
-				return fmt.Errorf("invalid version argument: %w", err)
+
+			oci := args[0]
+
+			if !strings.HasPrefix(oci, "oci://") {
+				return fmt.Errorf("invalid oci registry argument, must be formatted as oci uri ie. oci://whatever.dev/bar/test/foo:1.2.3-alpha")
 			}
 
-			if strings.HasPrefix(c.Registry, "oci://") {
-				c.Registry = strings.TrimPrefix(c.Registry, "oci://")
-			} else {
-				return fmt.Errorf("invalid registry argument, must be formatted as oci uri ie. oci://whatever.dev")
+			ref, err := registry.ParseReference(oci)
+			if err != nil {
+				return fmt.Errorf("invalid registry formatting: %s", oci)
 			}
+
+			version, err := semver.StrictNewVersion(ref.Reference)
+			name, _ := lo.Last(strings.Split(ref.Repository, "/"))
+
+			//version, err := semver.StrictNewVersion(c.Version)
+			//if err != nil {
+			//	return fmt.Errorf("invalid version argument: %w", err)
+			//}
+			//
+			//if strings.HasPrefix(c.Registry, "oci://") {
+			//	c.Registry = strings.TrimPrefix(c.Registry, "oci://")
+			//} else {
+			//	return fmt.Errorf("invalid registry argument, must be formatted as oci uri ie. oci://whatever.dev")
+			//}
 
 			cmd.SilenceUsage = true
 			publishDarConfig := &publishdar.DarConfig{
 				File:           c.File,
-				Name:           c.Name,
+				Name:           name,
 				Version:        version,
 				DryRun:         c.DryRun,
 				IncludeGitInfo: c.IncludeGitInfo,
 				Annotations:    c.Annotations,
-				Registry:       strings.TrimRight(c.Registry, "/"),
+				Registry:       fmt.Sprintf("%s/%s", ref.Registry, ref.Repository),
 				AuthFilePath:   c.RegistryAuth,
 				Insecure:       c.Insecure,
 				ExtraTags:      c.ExtraTags,
@@ -50,10 +68,10 @@ func Cmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&c.Name, publishcmd.DarNameFlagName, "n", "", "name of dar to be pushed")
-	cmd.MarkFlagRequired(publishcmd.DarNameFlagName)
-	cmd.Flags().StringVarP(&c.Version, publishcmd.VersionFlagName, "v", "", "version of dar to be pushed")
-	cmd.MarkFlagRequired(publishcmd.VersionFlagName)
+	//cmd.Flags().StringVarP(&c.Name, publishcmd.DarNameFlagName, "n", "", "name of dar to be pushed")
+	//cmd.MarkFlagRequired(publishcmd.DarNameFlagName)
+	//cmd.Flags().StringVarP(&c.Version, publishcmd.VersionFlagName, "v", "", "version of dar to be pushed")
+	//cmd.MarkFlagRequired(publishcmd.VersionFlagName)
 
 	cmd.Flags().BoolVarP(&c.DryRun, "dry-run", "d", false, "don't actually push to the registry")
 	cmd.Flags().BoolVarP(&c.IncludeGitInfo, "include-git-info", "g", false, "include git info as annotations on the published manifest")
@@ -64,7 +82,7 @@ func Cmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&c.ExtraTags, "extra-tags", "t", []string{}, "publish extra tags besides the semver")
 
-	cmd.Flags().StringVar(&c.Registry, "registry", "", "OCI registry to use for pushing")
+	//cmd.Flags().StringVar(&c.Registry, "registry", "", "OCI registry to use for pushing")
 	cmd.Flags().BoolVar(&c.Insecure, "insecure", false, "use http instead of https for OCI registry")
 	cmd.Flags().StringVar(&c.RegistryAuth, "auth", "", "path to a config file similar to docker’s config.json to use for authenticating to the OCI registry. Defaults to docker's config.json")
 

--- a/cmd/dpm/cmd/publish/dar/dar.go
+++ b/cmd/dpm/cmd/publish/dar/dar.go
@@ -68,11 +68,6 @@ func Cmd() *cobra.Command {
 		},
 	}
 
-	//cmd.Flags().StringVarP(&c.Name, publishcmd.DarNameFlagName, "n", "", "name of dar to be pushed")
-	//cmd.MarkFlagRequired(publishcmd.DarNameFlagName)
-	//cmd.Flags().StringVarP(&c.Version, publishcmd.VersionFlagName, "v", "", "version of dar to be pushed")
-	//cmd.MarkFlagRequired(publishcmd.VersionFlagName)
-
 	cmd.Flags().BoolVarP(&c.DryRun, "dry-run", "d", false, "don't actually push to the registry")
 	cmd.Flags().BoolVarP(&c.IncludeGitInfo, "include-git-info", "g", false, "include git info as annotations on the published manifest")
 	cmd.Flags().StringToStringVarP(&c.Annotations, "annotations", "a", map[string]string{}, "annotations to include in the published OCI artifact")
@@ -82,7 +77,6 @@ func Cmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&c.ExtraTags, "extra-tags", "t", []string{}, "publish extra tags besides the semver")
 
-	//cmd.Flags().StringVar(&c.Registry, "registry", "", "OCI registry to use for pushing")
 	cmd.Flags().BoolVar(&c.Insecure, "insecure", false, "use http instead of https for OCI registry")
 	cmd.Flags().StringVar(&c.RegistryAuth, "auth", "", "path to a config file similar to docker’s config.json to use for authenticating to the OCI registry. Defaults to docker's config.json")
 

--- a/docs-internal/src/cli/dpm_publish_component.rst
+++ b/docs-internal/src/cli/dpm_publish_component.rst
@@ -16,7 +16,7 @@ Will publish the component (OCI index) to <registry>/<name>:<version>
 
 ::
 
-  dpm publish component registry [flags]
+  dpm publish component <registry> [flags]
 
 Examples
 ~~~~~~~~

--- a/docs-internal/src/cli/dpm_publish_component.rst
+++ b/docs-internal/src/cli/dpm_publish_component.rst
@@ -16,14 +16,14 @@ Will publish the component (OCI index) to <registry>/<name>:<version>
 
 ::
 
-  dpm publish component [flags]
+  dpm publish component registry [flags]
 
 Examples
 ~~~~~~~~
 
 ::
 
-  dpm artifacts publish component --name foo --version 1.2.3-alpha -p linux/amd64=dist/foo-linux -p darwin/arm64=dist/foo-darwin --registry 'oci://whatever.dev/bar/test'
+  dpm artifacts publish component 'oci://whatever.dev/bar/test/foo:1.2.3-alpha' -p linux/amd64=dist/foo-linux -p darwin/arm64=dist/foo-darwin 
 
 Options
 ~~~~~~~
@@ -37,10 +37,7 @@ Options
   -h, --help                         help for component
   -g, --include-git-info             include git info as annotations on the published manifest
       --insecure                     use http instead of https for OCI registry
-  -n, --name string                  name of component to be pushed
   -p, --platform stringToString      REQUIRED <os>/<arch>=<path-to-component> or generic=<path-to-component> (default [])
-      --registry string              OCI registry to use for pushing
-  -v, --version string               version of component to be pushed
 
 SEE ALSO
 ~~~~~~~~

--- a/pkg/ocipusher/darpusher/darpusher.go
+++ b/pkg/ocipusher/darpusher/darpusher.go
@@ -36,7 +36,7 @@ func (op *DarPushOperation) Tag() string {
 }
 
 func (op *DarPushOperation) DarDestination(registry string) string {
-	return fmt.Sprintf("%s/%s:%s", registry, op.repoName, op.Tag())
+	return fmt.Sprintf("%s:%s", registry, op.Tag())
 }
 
 func DarNew(ctx context.Context, opts DarOpts) (*DarPushOperation, error) {

--- a/pkg/publishcmd/publishcmd.go
+++ b/pkg/publishcmd/publishcmd.go
@@ -11,10 +11,6 @@ import (
 
 const PlatformFlagName = "platform"
 const FileFlagName = "file"
-const RegistryFlagName = "registry"
-const ComponentNameFlagName = "name"
-const DarNameFlagName = "name"
-const VersionFlagName = "version"
 
 type PublishCmd struct {
 	DryRun, IncludeGitInfo bool

--- a/pkg/publishdar/publishdar.go
+++ b/pkg/publishdar/publishdar.go
@@ -18,6 +18,7 @@ import (
 	"daml.com/x/assistant/pkg/ociindex"
 	"daml.com/x/assistant/pkg/ocilister"
 	"daml.com/x/assistant/pkg/ocipusher/darpusher"
+	"daml.com/x/assistant/pkg/publish"
 	"daml.com/x/assistant/pkg/utils"
 	"github.com/Masterminds/semver/v3"
 	"github.com/fatih/color"
@@ -36,7 +37,7 @@ type DarConfig struct {
 	Annotations            map[string]string
 	ExtraTags              []string
 
-	Registry     string
+	Destination  *publish.Destination
 	AuthFilePath string
 	Insecure     bool
 }
@@ -60,11 +61,11 @@ func (p *DarPublisher) PublishDar(ctx context.Context) (err error) {
 			return nil
 		}
 
-		if p.config.Registry == "" {
+		if p.config.Destination.Registry == "" {
 			return fmt.Errorf("--registy must be provided when not in dry-run mode")
 		}
 
-		client, err := assistantremote.New(p.config.Registry, p.config.AuthFilePath, p.config.Insecure)
+		client, err := assistantremote.New(p.config.Destination.Registry, p.config.AuthFilePath, p.config.Insecure)
 		if err != nil {
 			return err
 		}
@@ -85,7 +86,7 @@ func (p *DarPublisher) PublishDar(ctx context.Context) (err error) {
 		if p.config.ExtraTags != nil && len(p.config.ExtraTags) > 0 {
 			p.printer.Println("pushing extra tags...")
 			// Function below is not specifically for a generated index, can be utilized to setting tags to artifacts in general
-			err := ociindex.Tag(ctx, client, &ociconsts.DarArtifact{DarRepo: p.config.Name}, p.config.Version, p.config.ExtraTags)
+			err := ociindex.Tag(ctx, client, &ociconsts.DarArtifact{DarRepo: p.config.Destination.Artifact.RepoName()}, p.config.Version, p.config.ExtraTags)
 			if err != nil {
 				return err
 			}
@@ -118,7 +119,7 @@ func (p *DarPublisher) prepare(ctx context.Context, dir string) (*darpusher.DarP
 		maps.Copy(annotations, gitAnnotations)
 	}
 	var artifact ociconsts.Artifact
-	artifact = &ociconsts.DarArtifact{DarRepo: p.config.Name}
+	artifact = &ociconsts.DarArtifact{DarRepo: p.config.Destination.Artifact.RepoName()}
 
 	opts := darpusher.DarOpts{
 		Artifact: artifact,
@@ -172,7 +173,7 @@ func checkHasLicense(dir string) error {
 func (p *DarPublisher) checkVersionExists(ctx context.Context, op *darpusher.DarPushOperation, client *assistantremote.Remote) (bool, error) {
 	var tags []string
 
-	tags, found, err := ocilister.ListTags(ctx, client, p.config.Name)
+	tags, found, err := ocilister.ListTags(ctx, client, p.config.Destination.Artifact.RepoName())
 	if err != nil {
 		return false, err
 	}

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -5,6 +5,7 @@ package testutil
 
 import (
 	"context"
+	"fmt"
 	"net/http/httptest"
 	"path/filepath"
 	"runtime"
@@ -40,8 +41,8 @@ func TestdataPath(t *testing.T, path ...string) string {
 	return filepath.Join(p...)
 }
 
-func PushComponentUri(registry *httptest.Server, uri, pathToComponent string, extraTags ...string) (args []string) {
-	//uri := fmt.Sprintf("%s/%s", GetRemote(registry).Registry, repo)
+func PushComponentUri(registry *httptest.Server, repo, pathToComponent string, extraTags ...string) (args []string) {
+	uri := fmt.Sprintf("oci://%s/%s", GetRemote(registry).Registry, repo)
 
 	args = []string{"publish", "component", uri, "-p", "generic=" + pathToComponent}
 
@@ -55,8 +56,8 @@ func PushComponentUri(registry *httptest.Server, uri, pathToComponent string, ex
 	return args
 }
 
-func PushDarUri(registry *httptest.Server, uri, pathToComponent string) (args []string) {
-	//uri := fmt.Sprintf("%s/%s", GetRemote(registry).Registry, repo)
+func PushDarUri(registry *httptest.Server, repo, pathToComponent string) (args []string) {
+	uri := fmt.Sprintf("oci://%s/%s", GetRemote(registry).Registry, repo)
 	args = []string{"publish", "dar", uri,
 		"-f", pathToComponent,
 	}

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -5,7 +5,6 @@ package testutil
 
 import (
 	"context"
-	"fmt"
 	"net/http/httptest"
 	"path/filepath"
 	"runtime"
@@ -41,10 +40,10 @@ func TestdataPath(t *testing.T, path ...string) string {
 	return filepath.Join(p...)
 }
 
-func PushComponentUri(registry *httptest.Server, name, repo, tag, pathToComponent string, extraTags ...string) (args []string) {
-	uri := fmt.Sprintf("%s/%s", GetRemote(registry).Registry, repo)
+func PushComponentUri(registry *httptest.Server, uri, pathToComponent string, extraTags ...string) (args []string) {
+	//uri := fmt.Sprintf("%s/%s", GetRemote(registry).Registry, repo)
 
-	args = []string{"publish", "component", "--name", name, "--version", tag, "--registry", "oci://" + uri, "-p", "generic=" + pathToComponent}
+	args = []string{"publish", "component", uri, "-p", "generic=" + pathToComponent}
 
 	if strings.HasPrefix(registry.URL, "http://") {
 		args = append(args, "--insecure")
@@ -56,10 +55,10 @@ func PushComponentUri(registry *httptest.Server, name, repo, tag, pathToComponen
 	return args
 }
 
-func PushDarUri(registry *httptest.Server, name, repo, tag, pathToComponent string) (args []string) {
-	uri := fmt.Sprintf("%s/%s", GetRemote(registry).Registry, repo)
-	args = []string{"publish", "dar", "--name", name, "--version", tag,
-		"-f", pathToComponent, "--registry", "oci://" + uri,
+func PushDarUri(registry *httptest.Server, uri, pathToComponent string) (args []string) {
+	//uri := fmt.Sprintf("%s/%s", GetRemote(registry).Registry, repo)
+	args = []string{"publish", "dar", uri,
+		"-f", pathToComponent,
 	}
 	if strings.HasPrefix(registry.URL, "http://") {
 		args = append(args, "--insecure")


### PR DESCRIPTION
- Refactor publish dar to use destination for easier parsing of args
- For both publish commands, remove name/version/registry from publish commands in favor of full uri
Note: Still leaving those values in place in configs for backwards compatibility with the soon to be delete repo commands