### PR TITLE
use python venv in `make run-internal-docs` to avoid missing deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ target
 dist/
 
 .direnv
+.venv-docs/
 
 !pkg/testutil/testdata/assistant-binary/windows/dpm.exe
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This page gives a high-level overview of how to contribute to the development of
 
 ## Development documentation
 
-Developers working on the internals of `dpm`, or are working on developing components can run `make run-internal-docs` to view more documentation. Note that this documentation is intended for contributors to `dpm`, and is _not_ part of the public API of `dpm`.
+Developers working on the internals of `dpm`, or are working on developing components can run `make run-internal-docs` to view more documentation. This will bootstrap a local docs virtual environment in `.venv-docs` from `requirements-docs.txt` if needed. You can also run `make install-docs-deps` explicitly to prepare the docs environment ahead of time. Note that this documentation is intended for contributors to `dpm`, and is _not_ part of the public API of `dpm`.
 
 ## Issues
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ endif
 # Controls for assistant execution:
 export DPM_LOG_LEVEL ?= debug
 ASSISTANT_ARGS ?=
+DOCS_VENV ?= .venv-docs
+DOCS_PYTHON := $(DOCS_VENV)/bin/python
+DOCS_REQUIREMENTS := requirements-docs.txt
 
 # Build locally in one go:
 local-build:
@@ -48,10 +51,19 @@ check-stale-docs:
 	)
 	@echo "✅ CLI docs are up to date."
 
+.PHONY: install-docs-deps
+install-docs-deps: $(DOCS_VENV)/.installed
+
+$(DOCS_VENV)/.installed: $(DOCS_REQUIREMENTS)
+	python3 -m venv $(DOCS_VENV)
+	$(DOCS_PYTHON) -m pip install --upgrade pip
+	$(DOCS_PYTHON) -m pip install -r $(DOCS_REQUIREMENTS)
+	touch $(DOCS_VENV)/.installed
+
 .PHONY: generate-sphinx
-generate-sphinx:
+generate-sphinx: $(DOCS_VENV)/.installed
 	rm -rf docs-internal/generated
-	sphinx-build -vvv -b html docs-internal/src/ docs-internal/generated/html
+	$(DOCS_PYTHON) -m sphinx -vvv -b html docs-internal/src/ docs-internal/generated/html
 
 .PHONY: run-internal-docs
 run-internal-docs: generate-cli-ref generate-sphinx
@@ -60,5 +72,5 @@ run-internal-docs: generate-cli-ref generate-sphinx
 .PHONY: run-docs
 run-docs: run-internal-docs
 	rm -rf docs/generated
-	sphinx-build -vvv -b html docs/src/ docs/generated/html
+	$(DOCS_PYTHON) -m sphinx -vvv -b html docs/src/ docs/generated/html
 	open docs/generated/html/index.html

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-rtd-theme


### PR DESCRIPTION
## Summary
Use a repo-local docs python virtual environment with `sphinx` as a dependency, instead of relying on globally installed Python packages or `sphinx-build` being available on PATH.

This makes the docs workflow replicable across machines and avoids conflicts with local Python dependency setups.

## To Consider
The shared docs dependencies live in `./requirements-docs.txt` at the repo root because the same `.venv-docs` virtual env is used for both internal and public docs builds; if it is later decided to separate those concerns, the requirements file can be moved accordingly.

## The problem
When running `make run-internal-docs` for the first time after cloning the repository, I got this error output:
```
rm -rf docs-internal/src/cli
go run cmd/docs/docs.go docs-internal/src/cli --format=rst
time=2026-04-28T11:53:49.732+02:00 level=DEBUG msg="no custom registry auth provided. Will default to docker's if present on system"
You currently do not have an SDK installed.
You may opt in to specific components by installing a specific SDK version or by using `multi-package.yaml` or `daml.yaml`, or see the docs for more info.
generating index.rst...
successfully generated at docs-internal/src/cli
rm -rf docs-internal/generated
sphinx-build -vvv -b html docs-internal/src/ docs-internal/generated/html
make: sphinx-build: No such file or directory
make: *** [generate-sphinx] Error 1
```

Essentially, I didn't have `sphinx-build` in my `PATH`, nor it was installed. Installing it with just `pip install` was conflicting with my `homebrew` setup, and broadly speaking, it could conflict with other people's local dependencies setup too. So to fix this, I made it so that `make run-internal-docs` now creates a local python venv with the dependencies in `./requirements-docs.txt`, including `sphinx`.

Running `make run-internal-docs` should now work out of the box for everyone, provided they have Python installed, but independently of their local dependencies and setup.

I welcome any suggestion or correction to my approach. I hope this is helpful and useful to others!