### PR TITLE
Fix bug around sdkless loading of commands

### DIFF
--- a/cmd/dpm/cmd/assistant.go
+++ b/cmd/dpm/cmd/assistant.go
@@ -95,7 +95,7 @@ func RootCmd(ctx context.Context, da *assistant.DamlAssistant) (*cobra.Command, 
 	if shouldAddSdkCommands(da.OsArgs) {
 		sdkCommands, err := da.ComputeSdkCommandsFromAssemblyPlan(ctx, config, resolutionType)
 		if errors.Is(err, assistantconfig.ErrNoSdkInstalled) {
-			cmd.PrintErrf("You currently do not have an SDK installed.\nYou may opt in to specific components by installing a specific SDK version or by using `multi-package.yaml` or `daml.yaml`, or see the docs for more info.\n")
+			cmd.PrintErr("You currently do not have an SDK installed.\nYou may opt in to specific components by installing a specific SDK version or by using `multi-package.yaml` or `daml.yaml`, or see the docs for more info.\n")
 		} else if err != nil {
 			return nil, err
 		} else {

--- a/cmd/dpm/cmd/assistant.go
+++ b/cmd/dpm/cmd/assistant.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 
 	"daml.com/x/assistant/cmd/dpm/cmd/publish"
 	"daml.com/x/assistant/cmd/dpm/cmd/uninstall"
@@ -96,8 +95,7 @@ func RootCmd(ctx context.Context, da *assistant.DamlAssistant) (*cobra.Command, 
 	if shouldAddSdkCommands(da.OsArgs) {
 		sdkCommands, err := da.ComputeSdkCommandsFromAssemblyPlan(ctx, config, resolutionType)
 		if errors.Is(err, assistantconfig.ErrNoSdkInstalled) {
-			slog.Warn("You currently do not have an SDK installed.\nYou may opt in to specific components by installing a specific SDK version or by using `multi-package.yaml` or `daml.yaml`, or see the docs for more info.\n")
-			return nil, nil
+			cmd.PrintErrf("You currently do not have an SDK installed.\nYou may opt in to specific components by installing a specific SDK version or by using `multi-package.yaml` or `daml.yaml`, or see the docs for more info.\n")
 		} else if err != nil {
 			return nil, err
 		} else {

--- a/cmd/dpm/cmd/assistant.go
+++ b/cmd/dpm/cmd/assistant.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"daml.com/x/assistant/cmd/dpm/cmd/publish"
 	"daml.com/x/assistant/cmd/dpm/cmd/uninstall"
@@ -95,7 +96,8 @@ func RootCmd(ctx context.Context, da *assistant.DamlAssistant) (*cobra.Command, 
 	if shouldAddSdkCommands(da.OsArgs) {
 		sdkCommands, err := da.ComputeSdkCommandsFromAssemblyPlan(ctx, config, resolutionType)
 		if errors.Is(err, assistantconfig.ErrNoSdkInstalled) {
-			cmd.PrintErr("You currently do not have an SDK installed.\nYou may opt in to specific components by installing a specific SDK version or by using `multi-package.yaml` or `daml.yaml`, or see the docs for more info.\n")
+			slog.Warn("You currently do not have an SDK installed.\nYou may opt in to specific components by installing a specific SDK version or by using `multi-package.yaml` or `daml.yaml`, or see the docs for more info.\n")
+			return nil, nil
 		} else if err != nil {
 			return nil, err
 		} else {

--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -1242,8 +1242,9 @@ func (suite *MainSuite) TestSdklessHelp() {
 	t := suite.T()
 	t.Chdir(testutil.TestdataPath(t, "multi-package-no-sdk", testutil.OS))
 
-	cmd := createStdTestRootCmd(t, "--help")
-	require.NoError(t, cmd.Execute())
+	output := runHelpCommand(t)
+	assert.Contains(t, output, "meep")
+
 	testMeepyComponent(t)
 
 }

--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -1238,6 +1238,16 @@ func (suite *MainSuite) TestComponentInitFail() {
 
 }
 
+func (suite *MainSuite) TestSdklessHelp() {
+	t := suite.T()
+	t.Chdir(testutil.TestdataPath(t, "multi-package-no-sdk", testutil.OS))
+
+	cmd := createStdTestRootCmd(t, "--help")
+	require.NoError(t, cmd.Execute())
+	testMeepyComponent(t)
+
+}
+
 func assertSdkVersion(t *testing.T, sdkVersion string) {
 	cmd, r, w := createTestRootCmd(t, "versions")
 	assert.NoError(t, cmd.Execute())

--- a/pkg/assembler/assemblyplan/assemblyplan.go
+++ b/pkg/assembler/assemblyplan/assemblyplan.go
@@ -77,6 +77,7 @@ func NewShallow(ctx context.Context, config *assistantconfig.Config, a *assemble
 	var installedSdk *assistantconfig.InstalledSdkVersion
 
 	if damlPackagePath != "" {
+
 		damlPackage, err := damlpackage.Read(damlPackagePath)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -114,21 +115,32 @@ func NewShallow(ctx context.Context, config *assistantconfig.Config, a *assemble
 			}
 		}
 	} else {
-		installedSdk, err = assistantconfig.GetInstalledSdkVersion(config, sdkVersion)
-		if err != nil {
+		if sdkVersion == nil {
+			plan.Base = sdkmanifest.SdkManifest{
+				AbsolutePath: "",
+				Spec: &sdkmanifest.Spec{
+					Components: map[string]*sdkmanifest.Component{},
+				},
+			}
+		} else {
+			installedSdk, err = assistantconfig.GetInstalledSdkVersion(config, sdkVersion)
+			if err != nil {
+				return nil, err
+			}
+			base, err := sdkmanifest.ReadSdkManifest(installedSdk.ManifestPath)
+			if err != nil {
+				return nil, err
+			}
+			plan.Base = *base
+		}
+		if err := configureMultiPackage(plan); err != nil {
 			return nil, err
 		}
-
-		base, err := sdkmanifest.ReadSdkManifest(installedSdk.ManifestPath)
-		if err != nil {
-			return nil, err
-		}
-		plan.Base = *base
 	}
-
 	if err := configureMultiPackage(plan); err != nil {
 		return nil, err
 	}
+
 	return plan, nil
 }
 

--- a/pkg/testutil/testdata/multi-package-no-sdk/unix/multi-package.yaml
+++ b/pkg/testutil/testdata/multi-package-no-sdk/unix/multi-package.yaml
@@ -1,0 +1,6 @@
+packages:
+  - ../../daml-package/unix
+
+override-components:
+  meep:
+    local-path: ../../meepy-component/unix

--- a/pkg/testutil/testdata/multi-package-no-sdk/windows/multi-package.yaml
+++ b/pkg/testutil/testdata/multi-package-no-sdk/windows/multi-package.yaml
@@ -1,0 +1,6 @@
+packages:
+  - ../../daml-package/windows
+
+override-components:
+  meep:
+    local-path: ../../meepy-component/windows

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -4,6 +4,7 @@
 package versions
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -157,6 +158,9 @@ returns nil
 */
 func GetActiveVersion(config *assistantconfig.Config, damlPackagePath string) (*semver.Version, error) {
 	v, err := GetFloatyActiveVersion(config, damlPackagePath)
+	if errors.Is(err, assistantconfig.ErrNoSdkInstalled) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Fix bug where opt-in commands weren't appearing when using dpm --help without a global sdk or sdk specification in yaml file in drectory
- Simple test to ensure running help in sdkless env w/ no sdk specifications still loads in meta/meep command