### PR TITLE
wording tweaks for component opt-in

### DIFF
--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -887,7 +887,7 @@ func (suite *MainSuite) TestMultiPackageInstall() {
 		output, err := io.ReadAll(r)
 		require.NoError(t, err)
 		assert.Contains(t, string(output), "Successfully installed SDK "+sdkVersion)
-		assert.Contains(t, string(output), "No overrides to install")
+		assert.Contains(t, string(output), "No opt-in components to install")
 	})
 }
 

--- a/cmd/dpm/cmd/install/package/package.go
+++ b/cmd/dpm/cmd/install/package/package.go
@@ -26,7 +26,7 @@ func Cmd(config *assistantconfig.Config) *cobra.Command {
 	var skipSDK bool
 	cmd := &cobra.Command{
 		Use:    "package",
-		Short:  "install the SDK and all overrides (if any) for a package",
+		Short:  "install the SDK and all opt-in components (if any) for a package",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -121,7 +121,7 @@ func installOverrides(ctx context.Context, cmd *cobra.Command, config *assistant
 		assemblyPlan.MultiPackage = nil
 	}
 	if !assemblyPlan.HasOverrides() {
-		cmd.Println("No overrides to install")
+		cmd.Println("No opt-in components to install")
 		return nil
 	}
 	cmd.Println("Installing components...")
@@ -132,7 +132,7 @@ func installOverrides(ctx context.Context, cmd *cobra.Command, config *assistant
 	if err != nil {
 		return err
 	}
-	cmd.Println("Successfully installed overrides")
+	cmd.Println("Successfully installed opt-in components")
 	return nil
 }
 

--- a/cmd/dpm/cmd/install/package/package.go
+++ b/cmd/dpm/cmd/install/package/package.go
@@ -124,7 +124,7 @@ func installOverrides(ctx context.Context, cmd *cobra.Command, config *assistant
 		cmd.Println("No overrides to install")
 		return nil
 	}
-	cmd.Println("Installing overrides...")
+	cmd.Println("Installing components...")
 	err = utils.WithInstallLock(ctx, config.InstallLocalFilePath, func() error {
 		_, err := assemblyPlan.Assemble(ctx)
 		return err

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -380,7 +380,7 @@ func (a *Assembler) handleURI(ctx context.Context, comp *sdkmanifest.Component) 
 	}
 	if !ok {
 		if _, isRemote := a.puller.(*remotepuller.RemoteOciPuller); isRemote && !a.config.AutoInstall {
-			return "", fmt.Errorf("sdk component %q won't be downloaded because auto-install is disabled", comp.String())
+			return "", fmt.Errorf("component %q is currently not installed.  Run `dpm install package` to install", comp.String())
 		}
 		platform := simpleplatform.CurrentPlatform()
 		if a.overridePlatform != nil {
@@ -414,7 +414,7 @@ func (a *Assembler) handleOCI(ctx context.Context, comp *sdkmanifest.Component) 
 	}
 	if !ok {
 		if _, isRemote := a.puller.(*remotepuller.RemoteOciPuller); isRemote && !a.config.AutoInstall {
-			return "", fmt.Errorf("sdk component %q won't be downloaded because auto-install is disabled", comp.String())
+			return "", fmt.Errorf("component %q is currently not installed.  Run `dpm install package` to install", comp.String())
 		}
 		platform := simpleplatform.CurrentPlatform()
 		if a.overridePlatform != nil {


### PR DESCRIPTION
- Make it clear what a user needs to do to install components that are not currently installed
- Use the language of `opt-in components` in place of `overrides`