### PR TITLE
disallow usage of both components and sdk-version

### DIFF
--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -117,63 +117,6 @@ func (suite *MainSuite) TestResolveMultiPackageSubdir() {
 			nil})
 }
 
-func (suite *MainSuite) TestResolveMultiPackageSdkVersionWithOverrides() {
-
-	t := suite.T()
-	if testutil.OS == "windows" {
-		t.Skip("TODO #114 this test hates windows")
-		return
-	}
-
-	t.Run("3a: when in multi-package dir", func(t *testing.T) {
-		installSdk(t, []string{someSdkVersion})
-		t.Chdir(testutil.TestdataPath(t, "multi-package-sdk-version-overrides"))
-
-		t.Run("help command", func(t *testing.T) {
-			output := runHelpCommand(t)
-			assert.Contains(t, output, "meep")
-			assert.Contains(t, output, "javux")
-			assert.NotContains(t, output, "multipak")
-		})
-
-		t.Run("resolve command", func(t *testing.T) {
-			deepResolution := runResolveCommand(t)
-			assert.Len(t, deepResolution.Packages, 3)
-			assert.ElementsMatch(t,
-				lo.Keys(lo.Values(deepResolution.Packages)[0].ComponentsV2),
-				[]string{"meep", "javabro"})
-		})
-
-		t.Run("assert active sdk version", func(t *testing.T) {
-			assertActiveSdkVersion(t, someSdkVersion)
-		})
-	})
-
-	t.Run("3b: when in sub package dir", func(t *testing.T) {
-		installSdk(t, []string{someSdkVersion})
-		t.Chdir(testutil.TestdataPath(t, "multi-package-sdk-version-overrides", "main"))
-
-		t.Run("help command", func(t *testing.T) {
-			output := runHelpCommand(t)
-			assert.Contains(t, output, "meep")
-			assert.Contains(t, output, "javux")
-			assert.NotContains(t, output, "multipak")
-		})
-
-		t.Run("resolve command", func(t *testing.T) {
-			deepResolution := runResolveCommand(t)
-			assert.Len(t, deepResolution.Packages, 3)
-			assert.ElementsMatch(t,
-				lo.Keys(lo.Values(deepResolution.Packages)[0].ComponentsV2),
-				[]string{"meep", "javabro"})
-		})
-
-		t.Run("assert active sdk version", func(t *testing.T) {
-			assertActiveSdkVersion(t, someSdkVersion)
-		})
-	})
-}
-
 func (suite *MainSuite) TestResolveErrorsInResolutionFile() {
 	t := suite.T()
 
@@ -661,18 +604,13 @@ func installSdkForComponent(t *testing.T, sdkVersion, componentName, componentVe
 
 func (suite *MainSuite) TestAutoInstallDefaultDisabled() {
 	t := suite.T()
-	ctx := testutil.Context(t)
 
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.Chdir(cwd) })
-	err = os.Chdir(testutil.TestdataPath(t, "daml-package", testutil.OS))
-	if err != nil {
-		return
-	}
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "daml.yaml"), []byte(`sdk-version: 1.2.3-not-installed`), 0666))
 
-	da := &assistant.DamlAssistant{OsArgs: []string{os.Args[0]}}
-	_, err = RootCmd(ctx, da)
+	da := assistant.DamlAssistant{OsArgs: []string{DpmName}}
+	_, err := RootCmd(t.Context(), &da)
 	require.ErrorIs(t, err, assistantconfig.ErrTargetSdkNotInstalled)
 }
 
@@ -708,24 +646,14 @@ func (suite *MainSuite) TestHelpCommandUsesShallowResolution() {
 
 func (suite *MainSuite) TestLegacyDamlProjectEnvVar() {
 	t := suite.T()
-	ctx := testutil.Context(t)
-
-	t.Setenv(assistantconfig.DamlProjectEnvVar, testutil.TestdataPath(t, "daml-package", testutil.OS))
-
-	da := &assistant.DamlAssistant{OsArgs: []string{os.Args[0]}}
-	_, err := RootCmd(ctx, da)
-	require.ErrorIs(t, err, assistantconfig.ErrTargetSdkNotInstalled)
+	t.Setenv(assistantconfig.DamlPackageEnvVar, testutil.TestdataPath(t, "daml-package", testutil.OS))
+	assert.NoError(t, createStdTestRootCmd(t, "meep").Execute())
 }
 
 func (suite *MainSuite) TestLegacyDamlPackageEnvVar() {
 	t := suite.T()
-	ctx := testutil.Context(t)
-
-	t.Setenv(assistantconfig.DamlPackageEnvVar, testutil.TestdataPath(t, "daml-package", testutil.OS))
-
-	da := &assistant.DamlAssistant{OsArgs: []string{os.Args[0]}}
-	_, err := RootCmd(ctx, da)
-	require.ErrorIs(t, err, assistantconfig.ErrTargetSdkNotInstalled)
+	t.Setenv(assistantconfig.DamlProjectEnvVar, testutil.TestdataPath(t, "daml-package", testutil.OS))
+	assert.NoError(t, createStdTestRootCmd(t, "meep").Execute())
 }
 
 func (suite *MainSuite) TestDeepResolutionForSdkCommands() {
@@ -784,108 +712,6 @@ func testDeepResolutionForSdkCommands(t *testing.T, damlPackageEnvVar string) {
 	})
 }
 
-func (suite *MainSuite) TestMultiPackageComponentOverrides() {
-	t := suite.T()
-
-	t.Run("13a: when in multi-package dir", func(t *testing.T) {
-		installSdk(t, []string{someSdkVersion, someOtherSdkVersion})
-		t.Chdir(testutil.TestdataPath(t, "multi-package-all-in-one", testutil.OS))
-
-		t.Run("help command", func(t *testing.T) {
-			output := runHelpCommand(t)
-			assert.Contains(t, output, "meep")
-			assert.Contains(t, output, "multipak")
-			assert.NotContains(t, output, "javux")
-		})
-
-		t.Run("resolve command", func(t *testing.T) {
-			deepResolution := runResolveCommand(t)
-			assert.Len(t, deepResolution.Packages, 1)
-			assert.ElementsMatch(t,
-				lo.Keys(lo.Values(deepResolution.Packages)[0].ComponentsV2),
-				[]string{"multipak", "meep", "javabro"})
-		})
-
-		t.Run("assert active sdk version", func(t *testing.T) {
-			assertActiveSdkVersion(t, someSdkVersion)
-		})
-
-	})
-
-	t.Run("13b: when in sub package dir", func(t *testing.T) {
-		installSdk(t, []string{someSdkVersion, someOtherSdkVersion})
-		t.Chdir(testutil.TestdataPath(t, "multi-package-all-in-one", testutil.OS, "daml-package"))
-
-		t.Run("help command", func(t *testing.T) {
-			output := runHelpCommand(t)
-			assert.Contains(t, output, "meep")
-			assert.Contains(t, output, "multipak")
-			assert.Contains(t, output, "javux")
-		})
-
-		t.Run("resolve command", func(t *testing.T) {
-			deepResolution := runResolveCommand(t)
-			assert.Len(t, deepResolution.Packages, 1)
-			assert.ElementsMatch(t,
-				lo.Keys(lo.Values(deepResolution.Packages)[0].ComponentsV2),
-				[]string{"multipak", "meep", "javabro"})
-		})
-
-		t.Run("assert active sdk version", func(t *testing.T) {
-			assertActiveSdkVersion(t, someOtherSdkVersion)
-		})
-	})
-}
-
-func (suite *MainSuite) TestMultiPackageSdkAndComponentOverrides() {
-	t := suite.T()
-
-	installSdk(t, []string{someSdkVersion})
-
-	deepResolution := runResolveCommand(t)
-	assert.ElementsMatch(t,
-		lo.Keys(lo.Values(deepResolution.DefaultSDK)[0].ComponentsV2),
-		[]string{"meep"})
-
-	t.Run("when in multi-package dir", func(t *testing.T) {
-		t.Chdir(testutil.TestdataPath(t, "multi-package-all-in-one-with-null-package-sdk", testutil.OS))
-
-		t.Run("help command", func(t *testing.T) {
-			output := runHelpCommand(t)
-			assert.Contains(t, output, "meep")
-			assert.Contains(t, output, "multipak")
-			assert.NotContains(t, output, "javux")
-		})
-
-		t.Run("resolve command", func(t *testing.T) {
-			deepResolution := runResolveCommand(t)
-			assert.Len(t, deepResolution.Packages, 1)
-			assert.ElementsMatch(t,
-				lo.Keys(lo.Values(deepResolution.Packages)[0].ComponentsV2),
-				[]string{"multipak", "meep", "javabro"})
-		})
-	})
-
-	t.Run("when in sub package dir", func(t *testing.T) {
-		t.Chdir(testutil.TestdataPath(t, "multi-package-all-in-one-with-null-package-sdk", testutil.OS, "daml-package"))
-
-		t.Run("help command", func(t *testing.T) {
-			output := runHelpCommand(t)
-			assert.Contains(t, output, "meep")
-			assert.Contains(t, output, "multipak")
-			assert.Contains(t, output, "javux")
-		})
-
-		t.Run("resolve command", func(t *testing.T) {
-			deepResolution := runResolveCommand(t)
-			assert.Len(t, deepResolution.Packages, 1)
-			assert.ElementsMatch(t,
-				lo.Keys(lo.Values(deepResolution.Packages)[0].ComponentsV2),
-				[]string{"multipak", "meep", "javabro"})
-		})
-	})
-}
-
 func (suite *MainSuite) TestMultiPackageInstall() {
 	t := suite.T()
 
@@ -911,34 +737,6 @@ func (suite *MainSuite) TestMultiPackageInstall() {
 		assert.Contains(t, string(output), "Successfully installed SDK "+sdkVersion)
 		assert.Contains(t, string(output), "No opt-in components to install")
 	})
-}
-
-func (suite *MainSuite) TestMultiPackageSkip() {
-	t := suite.T()
-
-	tmpDir := t.TempDir()
-
-	cwd, err := os.Getwd()
-
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, os.Chdir(cwd)) })
-	require.NoError(t, os.Chdir(testutil.TestdataPath(t, "multi-package-sdk-skipping", testutil.OS)))
-	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDir)
-
-	cmd, r, w := createTestRootCmd(t, "install", "package", "--skip-sdk")
-
-	require.NoError(t, cmd.Execute())
-	assert.NoError(t, w.Close())
-	output, err := io.ReadAll(r)
-	require.NoError(t, err)
-	assert.Contains(t, string(output), "Skipping installation of multi-package")
-
-	ctx := testutil.Context(t)
-	da := &assistant.DamlAssistant{OsArgs: []string{os.Args[0]}}
-	_, err = RootCmd(ctx, da)
-
-	require.ErrorIs(t, err, assistantconfig.ErrTargetSdkNotInstalled)
-
 }
 
 func (suite *MainSuite) TestInstallPackageMultipleRegistries() {

--- a/cmd/dpm/cmd/component_overlay_test.go
+++ b/cmd/dpm/cmd/component_overlay_test.go
@@ -225,7 +225,7 @@ func (suite *MainSuite) TestComponentOverlay() {
 		}
 		t.Chdir(dirs.WorkingDir)
 
-		require.NoError(t, createStdTestRootCmd(t, "install", "package", "--skip-sdk").Execute())
+		require.NoError(t, createStdTestRootCmd(t, "install", "package").Execute())
 
 		return
 	}

--- a/cmd/dpm/cmd/install/package/package.go
+++ b/cmd/dpm/cmd/install/package/package.go
@@ -23,7 +23,6 @@ import (
 )
 
 func Cmd(config *assistantconfig.Config) *cobra.Command {
-	var skipSDK bool
 	cmd := &cobra.Command{
 		Use:    "package",
 		Short:  "install the SDK and all opt-in components (if any) for a package",
@@ -49,12 +48,8 @@ func Cmd(config *assistantconfig.Config) *cobra.Command {
 					if err != nil {
 						return err
 					}
-					if !skipSDK {
-						if err := installSdk(ctx, cmd, config, sdkVersion); err != nil {
-							return err
-						}
-					} else {
-						cmd.Println("Skipping installation of multi-package sdk version ", sdkVersion)
+					if err := installSdk(ctx, cmd, config, sdkVersion); err != nil {
+						return err
 					}
 				}
 
@@ -64,7 +59,7 @@ func Cmd(config *assistantconfig.Config) *cobra.Command {
 				for _, p := range pkgs {
 					cmd.Printf("Processing package %q...\n", p)
 					damlPackagePath := filepath.Join(p, assistantconfig.DamlPackageFilename)
-					processDamlPackage(ctx, cmd, modifiedConfig, damlPackagePath, skipSDK)
+					processDamlPackage(ctx, cmd, modifiedConfig, damlPackagePath)
 					installOverrides(ctx, cmd, config, damlPackagePath, true)
 				}
 
@@ -76,17 +71,16 @@ func Cmd(config *assistantconfig.Config) *cobra.Command {
 				if !isDamlPackage {
 					return fmt.Errorf("not in a package directory or subdirectory")
 				}
-				processDamlPackage(ctx, cmd, modifiedConfig, damlPackagePath, skipSDK)
+				processDamlPackage(ctx, cmd, modifiedConfig, damlPackagePath)
 				return installOverrides(ctx, cmd, config, damlPackagePath, false)
 			}
 			return nil
 		},
 	}
 
-	cmd.Flags().BoolVar(&skipSDK, "skip-sdk", false, "run install packages with overwrites only")
 	return cmd
 }
-func processDamlPackage(ctx context.Context, cmd *cobra.Command, config *assistantconfig.Config, damlPath string, skip bool) error {
+func processDamlPackage(ctx context.Context, cmd *cobra.Command, config *assistantconfig.Config, damlPath string) error {
 	damlPackage, err := damlpackage.Read(damlPath)
 	if err != nil {
 		return err
@@ -96,12 +90,8 @@ func processDamlPackage(ctx context.Context, cmd *cobra.Command, config *assista
 		if err != nil {
 			return err
 		}
-		if !skip {
-			if err := installSdk(ctx, cmd, config, sdkVersion); err != nil {
-				return err
-			}
-		} else {
-			cmd.Println("Skipping installation of SDK with version:", sdkVersion)
+		if err := installSdk(ctx, cmd, config, sdkVersion); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/cmd/dpm/cmd/versions/versions.go
+++ b/cmd/dpm/cmd/versions/versions.go
@@ -139,7 +139,7 @@ func getActiveVersion(config *assistantconfig.Config) (*semver.Version, error) {
 		return nil, err
 	}
 
-	v, err := versions.GetActiveVersion(config, damlPackagePath)
+	v, _, err := versions.GetActiveVersion(config, damlPackagePath)
 	if errors.Is(err, assistantconfig.ErrNoSdkInstalled) || errors.Is(err, assistantconfig.ErrTargetSdkNotInstalled) {
 		return nil, nil
 	} else if err != nil {

--- a/pkg/assembler/assemblyplan/assemblyplan.go
+++ b/pkg/assembler/assemblyplan/assemblyplan.go
@@ -1,6 +1,9 @@
 // Copyright (c) 2017-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO refactor: rip out getOrAutoInstallPackageSdk() from here and replace with only a getPackageSdk()...
+// no need to further bloat this module with sdk installation
+
 package assemblyplan
 
 import (
@@ -19,6 +22,8 @@ import (
 	"daml.com/x/assistant/pkg/versions"
 	"github.com/Masterminds/semver/v3"
 )
+
+var ErrBothSdkAndComponentsInUse = fmt.Errorf("project uses both opt-in Components and SDK bundle, but dpm does not allow usage of both simultaneously")
 
 // AssemblyPlan decides what the final commands that'll be added to the assistant root command are,
 // or rather where they'll be sourced from.
@@ -39,6 +44,13 @@ type AssemblyPlan struct {
 
 	assembler *assembler.Assembler
 	config    *assistantconfig.Config
+}
+
+var emptyBase = sdkmanifest.SdkManifest{
+	AbsolutePath: "",
+	Spec: &sdkmanifest.Spec{
+		Components: map[string]*sdkmanifest.Component{},
+	},
 }
 
 func New(ctx context.Context, config *assistantconfig.Config, a *assembler.Assembler) (plan *AssemblyPlan, err error) {
@@ -63,49 +75,29 @@ func New(ctx context.Context, config *assistantconfig.Config, a *assembler.Assem
 }
 
 func NewShallow(ctx context.Context, config *assistantconfig.Config, a *assembler.Assembler, damlPackagePath string) (*AssemblyPlan, error) {
-	sdkVersion, err := versions.GetActiveVersion(config, damlPackagePath)
+	sdkVersion, sdkSrc, err := versions.GetActiveVersion(config, damlPackagePath)
 	if err != nil {
 		return nil, err
 	}
-
 	plan := &AssemblyPlan{
 		config:     config,
 		assembler:  a,
 		SdkVersion: sdkVersion,
 	}
 
-	var installedSdk *assistantconfig.InstalledSdkVersion
+	var damlPackage *damlpackage.DamlPackage
+	var multiPackage *multipackage.MultiPackage
+	var multiPackagePath string
 
+	// Add user-specified Components from daml.yaml / multi-package.yaml (if any)
 	if damlPackagePath != "" {
-
-		damlPackage, err := damlpackage.Read(damlPackagePath)
+		damlPackage, err = damlpackage.Read(damlPackagePath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, resolutionerrors.NewDamlYamlNotFoundError(err)
 			}
 			return nil, resolutionerrors.NewMalformedDamlYamlError(err)
 		}
-
-		if sdkVersion == nil {
-			plan.Base = sdkmanifest.SdkManifest{
-				AbsolutePath: "",
-				Spec: &sdkmanifest.Spec{
-					Components: map[string]*sdkmanifest.Component{},
-				},
-			}
-		} else {
-			installedSdk, err = getOrAutoInstallPackageSdk(ctx, config, sdkVersion.String(), damlPackagePath)
-			if err != nil {
-				return nil, err
-			}
-
-			base, err := sdkmanifest.ReadSdkManifest(installedSdk.ManifestPath)
-			if err != nil {
-				return nil, err
-			}
-			plan.Base = *base
-		}
-
 		if damlPackage.Components != nil {
 			plan.DamlPackage = &sdkmanifest.SdkManifest{
 				AbsolutePath: damlPackagePath,
@@ -114,31 +106,62 @@ func NewShallow(ctx context.Context, config *assistantconfig.Config, a *assemble
 				},
 			}
 		}
-	} else {
-		if sdkVersion == nil {
-			plan.Base = sdkmanifest.SdkManifest{
-				AbsolutePath: "",
-				Spec: &sdkmanifest.Spec{
-					Components: map[string]*sdkmanifest.Component{},
-				},
-			}
-		} else {
-			installedSdk, err = assistantconfig.GetInstalledSdkVersion(config, sdkVersion)
-			if err != nil {
-				return nil, err
-			}
-			base, err := sdkmanifest.ReadSdkManifest(installedSdk.ManifestPath)
-			if err != nil {
-				return nil, err
-			}
-			plan.Base = *base
-		}
-		if err := configureMultiPackage(plan); err != nil {
-			return nil, err
+	}
+	multiPackage, multiPackagePath, err = getMultiPackage()
+	if err != nil {
+		return nil, err
+	}
+	if multiPackage != nil && multiPackage.Components != nil {
+		plan.MultiPackage = &sdkmanifest.SdkManifest{
+			AbsolutePath: multiPackagePath,
+			Spec: &sdkmanifest.Spec{
+				Components: multiPackage.Components,
+			},
 		}
 	}
-	if err := configureMultiPackage(plan); err != nil {
-		return nil, err
+
+	if plan.HasOverrides() {
+		// Opt-in components case
+
+		plan.Base = emptyBase
+		if !(sdkVersion == nil || sdkSrc == versions.SdkVersionSourceGlobal) {
+			return nil, ErrBothSdkAndComponentsInUse
+		}
+	} else {
+		// SDK case
+
+		// TODO refactor / clean up this top-level "SDK case" branch some more
+		var installedSdk *assistantconfig.InstalledSdkVersion
+		if damlPackage != nil {
+			if sdkVersion == nil {
+				plan.Base = emptyBase
+			} else {
+				installedSdk, err = getOrAutoInstallPackageSdk(ctx, config, sdkVersion.String(), damlPackagePath)
+				if err != nil {
+					return nil, err
+				}
+
+				base, err := sdkmanifest.ReadSdkManifest(installedSdk.ManifestPath)
+				if err != nil {
+					return nil, err
+				}
+				plan.Base = *base
+			}
+		} else {
+			if sdkVersion == nil {
+				plan.Base = emptyBase
+			} else {
+				installedSdk, err = assistantconfig.GetInstalledSdkVersion(config, sdkVersion)
+				if err != nil {
+					return nil, err
+				}
+				base, err := sdkmanifest.ReadSdkManifest(installedSdk.ManifestPath)
+				if err != nil {
+					return nil, err
+				}
+				plan.Base = *base
+			}
+		}
 	}
 
 	return plan, nil
@@ -168,35 +191,28 @@ func getOrAutoInstallPackageSdk(ctx context.Context, config *assistantconfig.Con
 	return installedSdk, nil
 }
 
-// configureMultiPackage mutates the AssemblyPlan to account for multi-package.yaml (if any)
-func configureMultiPackage(plan *AssemblyPlan) error {
+func getMultiPackage() (multiPackage *multipackage.MultiPackage, multiPackagePath string, err error) {
 	multiPackagePath, hasMultiPackage, err := assistantconfig.GetMultiPackageAbsolutePath()
 	if err != nil {
-		return err
+		return nil, "", err
 	}
 	if !hasMultiPackage {
-		return nil
+		return nil, "", nil
 	}
-	multiPackage, err := multipackage.Read(multiPackagePath)
+	multiPackage, err = multipackage.Read(multiPackagePath)
 	if err != nil {
-		return err
+		return nil, "", err
 	}
 
-	plan.MultiPackage = &sdkmanifest.SdkManifest{
-		AbsolutePath: multiPackagePath,
-		Spec: &sdkmanifest.Spec{
-			Components: multiPackage.Components,
-		},
-	}
-	return nil
+	return multiPackage, multiPackagePath, nil
 }
 
 func (plan *AssemblyPlan) getOverrides() (assemblies []*sdkmanifest.SdkManifest) {
-	if plan.MultiPackage != nil {
+	if plan.MultiPackage != nil && len(plan.MultiPackage.Spec.Components) > 0 {
 		assemblies = append(assemblies, plan.MultiPackage)
 	}
 
-	if plan.DamlPackage != nil {
+	if plan.DamlPackage != nil && len(plan.DamlPackage.Spec.Components) > 0 {
 		assemblies = append(assemblies, plan.DamlPackage)
 	}
 	return

--- a/pkg/assembler/assemblyplan/assemblyplan_test.go
+++ b/pkg/assembler/assemblyplan/assemblyplan_test.go
@@ -4,7 +4,6 @@
 package assemblyplan
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,21 +17,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAssemblyPlan(t *testing.T) {
+func TestAssemblyPlanForSdkBundle(t *testing.T) {
 	t.Setenv(assistantconfig.EditionEnvVar, "open-source")
-	_, commands := loadDamlPackage(t, testutil.TestdataPath(t, "installed-sdks"), testutil.TestdataPath(t, "daml-package", testutil.OS), "9.9.9")
-	require.ElementsMatchf(t, lo.Keys(commands), []string{"meep", "javabro"}, "")
+	_, commands := loadDamlPackage(t, testutil.TestdataPath(t, "installed-sdks"), testutil.TestdataPath(t, "daml-package-sdk-only"), "9.9.9")
+	require.ElementsMatch(t, lo.Keys(commands), []string{"meep"})
 
 	// overridden component
 	meepCommnads := commands["meep"]
-	require.Len(t, meepCommnads, 2)
+	require.Len(t, meepCommnads, 1)
 	assert.Equal(t, meepCommnads[0].ComponentName, "meep")
-	assert.Equal(t, meepCommnads[0].Command.GetName(), "meep")
-	assert.Equal(t, meepCommnads[1].ComponentName, "meep")
-	assert.Equal(t, meepCommnads[1].Command.GetName(), "show-env-vars")
+	assert.Equal(t, meepCommnads[0].Command.GetName(), "useless")
 }
 
-func TestAssemblyPlanCommandConflict(t *testing.T) {
+func TestAssemblyPlanForOptInComponents(t *testing.T) {
+	t.Setenv(assistantconfig.EditionEnvVar, "open-source")
+	_, commands := loadDamlPackage(t, testutil.TestdataPath(t, "installed-sdks"), testutil.TestdataPath(t, "daml-package", testutil.OS), "")
+	require.ElementsMatchf(t, lo.Keys(commands), []string{"meep", "javabro"}, "")
+
+}
+
+func TestAssemblyPlanCommandConflictSdkBundle(t *testing.T) {
+	ctx := testutil.Context(t)
+
+	t.Setenv(assistantconfig.EditionEnvVar, "open-source")
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	plan := load(t,
+		filepath.Join(cwd, "command-conflict-testcase", "installed-sdks"),
+		filepath.Join(cwd, "command-conflict-testcase", "daml-package-sdk-only"),
+		"1.2.123",
+	)
+
+	_, err = plan.Assemble(ctx)
+	assert.ErrorContains(t, err, "defined in multiple components")
+}
+
+func TestAssemblyPlanCommandWithOptInComponents(t *testing.T) {
 	ctx := testutil.Context(t)
 
 	t.Setenv(assistantconfig.EditionEnvVar, "open-source")
@@ -42,11 +63,11 @@ func TestAssemblyPlanCommandConflict(t *testing.T) {
 	plan := load(t,
 		filepath.Join(cwd, "command-conflict-testcase", "installed-sdks"),
 		filepath.Join(cwd, "command-conflict-testcase", "daml-package"),
-		"1.2.123",
+		"",
 	)
 
 	_, err = plan.Assemble(ctx)
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "defined in multiple components")
 }
 
 func TestMultiPackage(t *testing.T) {
@@ -59,21 +80,13 @@ func TestMultiPackage(t *testing.T) {
 func loadMultiPackage(t *testing.T) (*AssemblyPlan, map[string][]*assembler.ValidatedCommand) {
 	p := testutil.TestdataPath(t, "multi-package", testutil.OS)
 	t.Setenv(assistantconfig.DamlMultiPackageEnvVar, p)
-	return loadDamlPackage(t, testutil.TestdataPath(t, "installed-sdks"), testutil.TestdataPath(t, "daml-package", testutil.OS), "9.9.9")
+	return loadDamlPackage(t, testutil.TestdataPath(t, "installed-sdks"), testutil.TestdataPath(t, "daml-package", testutil.OS), "")
 }
 
 func load(t *testing.T, installedSdksPath, damlPackagePath, sdkVersion string) *AssemblyPlan {
 	ctx := testutil.Context(t)
 
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-	// reset original cwd
-	defer func() { require.NoError(t, os.Chdir(cwd)) }()
-
-	// this will make daml.yaml in the CWD
-	require.NoError(t, os.Chdir(damlPackagePath))
-	newCwd, _ := os.Getwd()
-	fmt.Println(newCwd)
+	t.Chdir(damlPackagePath)
 
 	config := &assistantconfig.Config{
 		Edition:                   assistantconfig.NewLazyEdition(sdkmanifest.OpenSource),
@@ -85,9 +98,15 @@ func load(t *testing.T, installedSdksPath, damlPackagePath, sdkVersion string) *
 
 	plan, err := New(ctx, config, a)
 	require.NoError(t, err)
-	assert.Equal(t, plan.Base.Spec.Version.Value().String(), sdkVersion)
 
-	require.NotNil(t, plan.DamlPackage)
+	if sdkVersion == "" {
+		assert.Nil(t, plan.Base.Spec.Version)
+		require.NotNil(t, plan.DamlPackage)
+	} else {
+		// component opt-in case
+		assert.Equal(t, plan.Base.Spec.Version.Value().String(), sdkVersion)
+		require.Nil(t, plan.DamlPackage) // this field is nil when there are no 'components'
+	}
 
 	return plan
 }

--- a/pkg/assembler/assemblyplan/command-conflict-testcase/daml-package-sdk-only/daml.yaml
+++ b/pkg/assembler/assemblyplan/command-conflict-testcase/daml-package-sdk-only/daml.yaml
@@ -1,3 +1,4 @@
+sdk-version: 1.2.123
 build-options:
   - --target=2.1
 codegen:
@@ -37,11 +38,3 @@ typecheck-upgrades: true
 upgrades: ..
 version: 0.0.0.1
 #module-prefixes: !java.util.LinkedHashMap
-override-components:
-  foo:
-    local-path: ../foo-component
-
-  bar:
-    local-path: ../bar-component
-
-

--- a/pkg/assembler/assemblyplan/command-conflict-testcase/daml-package/daml.yaml
+++ b/pkg/assembler/assemblyplan/command-conflict-testcase/daml-package/daml.yaml
@@ -37,11 +37,11 @@ typecheck-upgrades: true
 upgrades: ..
 version: 0.0.0.1
 #module-prefixes: !java.util.LinkedHashMap
-override-components:
-  foo:
-    local-path: ../foo-component
+components:
+  - name: foo
+    path: ../foo-component
 
-  bar:
-    local-path: ../bar-component
+  - name: bar
+    path: ../bar-component
 
 

--- a/pkg/assembler/assemblyplan/command-conflict-testcase/installed-sdks/open-source/1.2.123.yaml
+++ b/pkg/assembler/assemblyplan/command-conflict-testcase/installed-sdks/open-source/1.2.123.yaml
@@ -6,3 +6,6 @@ spec:
   components:
     foo:
       local-path: ../../foo-component
+
+    bar:
+      local-path: ../../bar-component

--- a/pkg/packagelock/locker.go
+++ b/pkg/packagelock/locker.go
@@ -226,7 +226,7 @@ func (l *Locker) computeMultiExpectedLockfile(multiPackageDirAbsPath string) (*P
 }
 
 func (l *Locker) getSdkVersion(packageDirAbsPath string) (SdkVersion, error) {
-	sdkVersion, err := versions.GetFloatyActiveVersion(l.config, packageDirAbsPath)
+	sdkVersion, _, err := versions.GetFloatyActiveVersion(l.config, packageDirAbsPath)
 	if err != nil {
 		return SdkVersion{}, err
 	}

--- a/pkg/testutil/testdata/daml-package-sdk-only/daml.yaml
+++ b/pkg/testutil/testdata/daml-package-sdk-only/daml.yaml
@@ -1,0 +1,4 @@
+sdk-version: 9.9.9
+
+dependencies:
+  - daml-script

--- a/pkg/testutil/testdata/daml-package/unix/daml.yaml
+++ b/pkg/testutil/testdata/daml-package/unix/daml.yaml
@@ -1,10 +1,7 @@
-sdk-version: 9.9.9
 override-components:
-  # override
   meep:
     local-path: ../../meepy-component/unix
 
-  # add
   javabro:
     local-path: ../../javabro-component
 

--- a/pkg/testutil/testdata/daml-package/windows/daml.yaml
+++ b/pkg/testutil/testdata/daml-package/windows/daml.yaml
@@ -1,10 +1,7 @@
-sdk-version: 9.9.9
 override-components:
-  # override
   meep:
     local-path: ../../meepy-component/windows
 
-  # add
   javabro:
     local-path: ../../javabro-component
 

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -20,6 +20,20 @@ import (
 	"github.com/samber/lo"
 )
 
+// SdkVersionSource describes how the effective sdk version was determined.
+// It shouldn't be used to infer the actual value of the version.
+// For example, when the source is deemed to be SdkVersionSourceGlobal,
+// the version could be some non-blank version (1.2.3), or blank if there happens to not be any sdk installed
+type SdkVersionSource int
+
+const (
+	SdkVersionSourceEnvVar SdkVersionSource = iota
+	SdkVersionSourceDamlPackage
+	SdkVersionSourceMultiPackage
+	SdkVersionSourceGlobal
+	SdkVersionSourceNone
+)
+
 type Version struct {
 	Version   *semver.Version `json:"version,omitempty"`
 	Installed bool            `json:"installed,omitempty"`
@@ -156,38 +170,40 @@ returns nil
 - when we're in package context, and sdk-version is null or "" in both daml.yaml and multi-package.yaml
 - or when DPM_SDK_VERSION=""
 */
-func GetActiveVersion(config *assistantconfig.Config, damlPackagePath string) (*semver.Version, error) {
-	v, err := GetFloatyActiveVersion(config, damlPackagePath)
+func GetActiveVersion(config *assistantconfig.Config, damlPackagePath string) (*semver.Version, SdkVersionSource, error) {
+	v, src, err := GetFloatyActiveVersion(config, damlPackagePath)
 	if errors.Is(err, assistantconfig.ErrNoSdkInstalled) {
-		return nil, nil
+		return nil, SdkVersionSourceGlobal, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if v == assistantconfig.BlankSdkVersion {
-		return nil, nil
+		return nil, src, nil
 	}
-	return semver.StrictNewVersion(v)
+
+	semVer, err := semver.StrictNewVersion(v)
+	return semVer, src, err
 }
 
 // GetFloatyActiveVersion is the same as GetActiveVersion but permits floaty versions
-func GetFloatyActiveVersion(config *assistantconfig.Config, damlPackagePath string) (string, error) {
+func GetFloatyActiveVersion(config *assistantconfig.Config, damlPackagePath string) (string, SdkVersionSource, error) {
 	// DPM_SDK_VERSION override
 	versionOverride, ok := os.LookupEnv(assistantconfig.DpmSdkVersionEnvVar)
 	if ok {
-		return versionOverride, nil
+		return versionOverride, SdkVersionSourceEnvVar, nil
 	}
 
 	multiPackageVersion := ""
 
 	multiPackagePath, hasMultiPackage, err := assistantconfig.GetMultiPackageAbsolutePath()
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	if hasMultiPackage {
 		multiPackage, err := multipackage.Read(multiPackagePath)
 		if err != nil {
-			return "", err
+			return "", 0, err
 		}
 		multiPackageVersion = multiPackage.SdkVersion
 	}
@@ -197,25 +213,25 @@ func GetFloatyActiveVersion(config *assistantconfig.Config, damlPackagePath stri
 		damlPackage, err := damlpackage.Read(damlPackagePath)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return "", resolutionerrors.NewDamlYamlNotFoundError(err)
+				return "", 0, resolutionerrors.NewDamlYamlNotFoundError(err)
 			}
-			return "", resolutionerrors.NewMalformedDamlYamlError(err)
+			return "", 0, resolutionerrors.NewMalformedDamlYamlError(err)
 		}
 
 		if damlPackage.SdkVersion != "" {
-			return damlPackage.SdkVersion, nil
+			return damlPackage.SdkVersion, SdkVersionSourceDamlPackage, nil
 		} else if multiPackageVersion != "" {
-			return multiPackageVersion, nil
+			return multiPackageVersion, SdkVersionSourceMultiPackage, nil
 		}
 
-		// don't inherit the global sdk-version, instead use no sdk
-		return "", nil
+		// when both parent and child have null sdk, don't inherit the global sdk-version, instead use no sdk
+		return "", SdkVersionSourceNone, nil
 	}
 
 	// in a multi-package context
 	if hasMultiPackage {
 		if multiPackageVersion != "" {
-			return multiPackageVersion, nil
+			return multiPackageVersion, SdkVersionSourceMultiPackage, nil
 		}
 		// else: fallthrough to using the global sdk
 	}
@@ -223,7 +239,7 @@ func GetFloatyActiveVersion(config *assistantconfig.Config, damlPackagePath stri
 	// not in a package or multi-package context
 	s, err := assistantconfig.GetInstalledSdkFromEnvOrDefault(config)
 	if err != nil {
-		return "", err
+		return "", SdkVersionSourceGlobal, err
 	}
-	return s.Version.String(), nil
+	return s.Version.String(), SdkVersionSourceGlobal, nil
 }


### PR DESCRIPTION
- QoL / UX improvement so that users that use the opt-in components feature incorrectly by mixing it with SDK get an error message: `project uses both opt-in Components and SDK bundle, but dpm does not allow usage of both simultaneously`
- refactored `AssebmlyPlan`
- got rid of `--skip-sdk` flag for `dpm install package` as it doesn't make sense to have it given the premise of this PR 
- modified the tests accordingly