### PR TITLE
designate a tag that won't trigger releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
     needs: 
       - windows
       - linux
-    if: success() && startsWith(github.ref, 'refs/tags/')
+    if: success() && startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/tags/0.0.0-skiprelease'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
it's useful to have a tag for testing purpose so that `main`'s CI won't automatically trigger a release on.
I'll be relying on this to iterate on [creating](https://github.com/digital-asset/dpm/pull/186) Github Releases 