### PR TITLE
Implement generic publish command

### DIFF
--- a/cmd/dpm/cmd/artifacts_test.go
+++ b/cmd/dpm/cmd/artifacts_test.go
@@ -69,6 +69,36 @@ func (suite *RepoSuite) TestPublishThirdPartyComponents() {
 	})
 }
 
+func (suite *RepoSuite) TestPublishGenericArtifact() {
+	t := suite.T()
+	_, _ = testutil.StartRegistry(t)
+	uri := fmt.Sprintf("%s/x/y/z", os.Getenv(assistantconfig.OciRegistryEnvVar))
+
+	args := []string{"publish", fmt.Sprintf("oci://%s/meep:1.2.3", uri),
+		"-p", "windows/amd64=" + testutil.TestdataPath(t, "meepy-component", "windows"),
+		"-p", "linux/amd64=" + testutil.TestdataPath(t, "meepy-component", "unix"),
+		"-p", "darwin/amd64=" + testutil.TestdataPath(t, "meepy-component", "unix"),
+		"-p", "darwin/arm64=" + testutil.TestdataPath(t, "meepy-component", "unix"),
+	}
+
+	if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
+		args = append(args, "--insecure")
+	}
+	cmd := createStdTestRootCmd(t)
+	cmd.SetArgs(args)
+	require.NoError(t, cmd.Execute())
+
+	t.Run("exit if publishing existing tag", func(t *testing.T) {
+		cmd, r, w := createTestRootCmd(t, args...)
+		assert.NoError(t, cmd.Execute())
+		assert.NoError(t, w.Close())
+
+		output, err := io.ReadAll(r)
+		assert.NoError(t, err)
+		assert.Contains(t, string(output), "skipped pushing because component")
+	})
+}
+
 func (suite *RepoSuite) TestComponentTags() {
 	t := suite.T()
 	_, reg := testutil.StartRegistry(t)

--- a/cmd/dpm/cmd/publish/component/component.go
+++ b/cmd/dpm/cmd/publish/component/component.go
@@ -24,7 +24,7 @@ func Cmd() *cobra.Command {
 		Use:     "component <registry>",
 		Short:   "Publish a component to an OCI registry",
 		Long:    "Will publish the component (OCI index) to <registry>/<name>:<version>",
-		Example: "dpm artifacts publish component 'oci://whatever.dev/bar/test/foo:1.2.3-alpha' -p linux/amd64=dist/foo-linux -p darwin/arm64=dist/foo-darwin ",
+		Example: "dpm publish component 'oci://whatever.dev/bar/test/foo:1.2.3-alpha' -p linux/amd64=dist/foo-linux -p darwin/arm64=dist/foo-darwin ",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/cmd/dpm/cmd/publish/dar/dar.go
+++ b/cmd/dpm/cmd/publish/dar/dar.go
@@ -23,7 +23,7 @@ func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "dar <registry>",
 		Short:   "Publish a dar to an OCI registry",
-		Example: "dpm artifacts publish dar 'oci://whatever.dev/bar/test/foo:1.2.3-alpha' -f path/to/foo.dar",
+		Example: "dpm publish dar 'oci://whatever.dev/bar/test/foo:1.2.3-alpha' -f path/to/foo.dar",
 		Hidden:  !assistantconfig.DpmLockfileEnabled(), // Use single feature flag to represent features in current release
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/dpm/cmd/publish/publish.go
+++ b/cmd/dpm/cmd/publish/publish.go
@@ -4,18 +4,84 @@
 package publish
 
 import (
+	"fmt"
+	"strings"
+
 	publishcomponent "daml.com/x/assistant/cmd/dpm/cmd/publish/component"
 	publishdar "daml.com/x/assistant/cmd/dpm/cmd/publish/dar"
 	"daml.com/x/assistant/pkg/builtincommand"
+	ociconsts "daml.com/x/assistant/pkg/oci"
+	"daml.com/x/assistant/pkg/publish"
+	"daml.com/x/assistant/pkg/publishcmd"
+	"github.com/Masterminds/semver/v3"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2/registry"
 )
 
 func Cmd() *cobra.Command {
+	c := publishcmd.PublishCmd{}
 	cmd := &cobra.Command{
-		Use:   string(builtincommand.Publish),
-		Short: "Commands for publishing artifacts",
-		Long:  "Commands for publishing artifacts",
+		Use:   fmt.Sprintf("%s <registry>", string(builtincommand.Publish)),
+		Short: "Command for publishing an artifact to an OCI registry",
+		Long:  "Command/subcommands for publishing artifacts to an OCI registry",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			oci := args[0]
+
+			if strings.HasPrefix(oci, "oci://") {
+				oci = strings.TrimPrefix(oci, "oci://")
+			} else {
+				return fmt.Errorf("invalid oci registry argument, must be formatted as oci uri ie. oci://whatever.dev/bar/test/foo:1.2.3-alpha")
+			}
+
+			ref, err := registry.ParseReference(oci)
+			if err != nil {
+				return fmt.Errorf("invalid registry formatting: %s", oci)
+			}
+
+			version, err := semver.StrictNewVersion(ref.Reference)
+			name, _ := lo.Last(strings.Split(ref.Repository, "/"))
+
+			destination := &publish.Destination{
+				Registry: ref.Registry,
+				Artifact: &ociconsts.GenericArtifact{
+					ArtifactName: ref.Repository,
+				},
+			}
+
+			platforms, err := c.ParsePlatforms()
+			if err != nil {
+				return err
+			}
+
+			cmd.SilenceUsage = true
+			publishConfig := &publish.Config{
+				Platforms:      platforms,
+				Name:           name,
+				Version:        version,
+				DryRun:         c.DryRun,
+				IncludeGitInfo: c.IncludeGitInfo,
+				Annotations:    c.Annotations,
+				Destination:    destination,
+				AuthFilePath:   c.RegistryAuth,
+				Insecure:       c.Insecure,
+				ExtraTags:      c.ExtraTags,
+			}
+			return publish.New(publishConfig, cmd).Publish(cmd.Context())
+		},
 	}
+
+	cmd.Flags().BoolVarP(&c.DryRun, "dry-run", "d", false, "don't actually push to the registry")
+	cmd.Flags().BoolVarP(&c.IncludeGitInfo, "include-git-info", "g", false, "include git info as annotations on the published manifest")
+	cmd.Flags().StringToStringVarP(&c.Annotations, "annotations", "a", map[string]string{}, "annotations to include in the published OCI artifact")
+
+	cmd.Flags().StringToStringVarP(&c.Platforms, publishcmd.PlatformFlagName, "p", map[string]string{}, `REQUIRED <os>/<arch>=<path-to-component> or generic=<path-to-component>`)
+	cmd.MarkFlagRequired(publishcmd.PlatformFlagName)
+
+	cmd.Flags().StringSliceVarP(&c.ExtraTags, "extra-tags", "t", []string{}, "publish extra tags besides the semver")
+
+	cmd.Flags().BoolVar(&c.Insecure, "insecure", false, "use http instead of https for OCI registry")
+	cmd.Flags().StringVar(&c.RegistryAuth, "auth", "", "path to a config file similar to docker’s config.json to use for authenticating to the OCI registry. Defaults to docker's config.json")
 
 	cmd.AddCommand(publishcomponent.Cmd())
 	cmd.AddCommand(publishdar.Cmd())

--- a/docs-internal/src/cli/dpm.rst
+++ b/docs-internal/src/cli/dpm.rst
@@ -28,7 +28,7 @@ SEE ALSO
 * :ref:`dpm component <dpm_component>` 	 - commands for component development
 * :ref:`dpm install <dpm_install>` 	 - install a dpm-sdk
 * :ref:`dpm login <dpm_login>` 	 - 
-* :ref:`dpm publish <dpm_publish>` 	 - Commands for publishing artifacts
+* :ref:`dpm publish <dpm_publish>` 	 - Command for publishing an artifact to an OCI registry
 * :ref:`dpm repo <dpm_repo>` 	 - 
 * :ref:`dpm resolve <dpm_resolve>` 	 - 
 * :ref:`dpm tags <dpm_tags>` 	 - list published tags of an artifact

--- a/docs-internal/src/cli/dpm_publish.rst
+++ b/docs-internal/src/cli/dpm_publish.rst
@@ -6,20 +6,31 @@ Dpm Publish
 dpm publish
 -----------
 
-Commands for publishing artifacts
+Command for publishing an artifact to an OCI registry
 
 Synopsis
 ~~~~~~~~
 
 
-Commands for publishing artifacts
+Command/subcommands for publishing artifacts to an OCI registry
+
+::
+
+  dpm publish <registry> [flags]
 
 Options
 ~~~~~~~
 
 ::
 
-  -h, --help   help for publish
+  -a, --annotations stringToString   annotations to include in the published OCI artifact (default [])
+      --auth string                  path to a config file similar to docker’s config.json to use for authenticating to the OCI registry. Defaults to docker's config.json
+  -d, --dry-run                      don't actually push to the registry
+  -t, --extra-tags strings           publish extra tags besides the semver
+  -h, --help                         help for publish
+  -g, --include-git-info             include git info as annotations on the published manifest
+      --insecure                     use http instead of https for OCI registry
+  -p, --platform stringToString      REQUIRED <os>/<arch>=<path-to-component> or generic=<path-to-component> (default [])
 
 SEE ALSO
 ~~~~~~~~

--- a/docs-internal/src/cli/dpm_publish_component.rst
+++ b/docs-internal/src/cli/dpm_publish_component.rst
@@ -23,7 +23,7 @@ Examples
 
 ::
 
-  dpm artifacts publish component 'oci://whatever.dev/bar/test/foo:1.2.3-alpha' -p linux/amd64=dist/foo-linux -p darwin/arm64=dist/foo-darwin 
+  dpm publish component 'oci://whatever.dev/bar/test/foo:1.2.3-alpha' -p linux/amd64=dist/foo-linux -p darwin/arm64=dist/foo-darwin 
 
 Options
 ~~~~~~~
@@ -42,5 +42,5 @@ Options
 SEE ALSO
 ~~~~~~~~
 
-* :ref:`dpm publish <dpm_publish>` 	 - Commands for publishing artifacts
+* :ref:`dpm publish <dpm_publish>` 	 - Command for publishing an artifact to an OCI registry
 

--- a/pkg/oci/artifact.go
+++ b/pkg/oci/artifact.go
@@ -52,3 +52,13 @@ func (a *SdkManifestArtifact) RepoName() string {
 }
 func (a *SdkManifestArtifact) ArtifactType() string  { return AssemblyArtifactType }
 func (a *SdkManifestArtifact) FileMediaType() string { return AssemblyFileMediaType }
+
+type GenericArtifact struct {
+	ArtifactName string
+}
+
+func (a *GenericArtifact) RepoName() string {
+	return a.ArtifactName
+}
+func (a *GenericArtifact) ArtifactType() string  { return AssemblyArtifactType }
+func (a *GenericArtifact) FileMediaType() string { return AssemblyFileMediaType }

--- a/pkg/publish/publish.go
+++ b/pkg/publish/publish.go
@@ -76,18 +76,24 @@ func (p *Publisher) Publish(ctx context.Context) (err error) {
 	p.printer.Println("destination is " + p.config.Destination.String())
 
 	var pushOps []*ocipusher.PushOperation
-	if p.config.Name != sdkmanifest.AssistantName {
-		pushOps, err = p.prepareComponents(ctx)
-		if err != nil {
-			return err
-		}
-	} else {
+
+	if p.config.Name == sdkmanifest.AssistantName {
 		assistantPushOps, closeFn, err := p.prepareAssistant(ctx)
 		defer func() { _ = closeFn() }()
 		if err != nil {
 			return err
 		}
 		pushOps = assistantPushOps
+	} else if p.config.Destination.Artifact.ArtifactType() == ociconsts.ComponentArtifactType {
+		pushOps, err = p.prepareComponents(ctx)
+		if err != nil {
+			return err
+		}
+	} else {
+		pushOps, err = p.prepareGeneric(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	if p.config.DryRun {
@@ -215,6 +221,19 @@ func (p *Publisher) prepareComponents(ctx context.Context) ([]*ocipusher.PushOpe
 	var pushOps []*ocipusher.PushOperation
 	for platform, dir := range p.config.Platforms {
 		pushOp, err := p.prepareComponent(ctx, platform, dir)
+		if err != nil {
+			return nil, err
+		}
+
+		pushOps = append(pushOps, pushOp)
+	}
+	return pushOps, nil
+}
+
+func (p *Publisher) prepareGeneric(ctx context.Context) ([]*ocipusher.PushOperation, error) {
+	var pushOps []*ocipusher.PushOperation
+	for platform, dir := range p.config.Platforms {
+		pushOp, err := p.prepare(ctx, platform, dir)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Implement `dpm publish <registry>` to allow for publishing of generic components and oci
- Small syntax changes around command description
- Update docs