### PR TITLE
Publish to ghcr instead of gar

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -4,7 +4,6 @@ inputs:
   registry:
     type: string
     description: GAR registry to use when publishing
-#    default: "europe-docker.pkg.dev"
     default: "ghcr.io/digital-asset"
   repo:
     type: string

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -15,10 +15,10 @@ inputs:
     type: string
     description: Additional flags to pass to goreleaser
     default: "--snapshot"
-  key:
-    type: string
-    description: auth key
-    required: true
+#  key:
+#    type: string
+#    description: auth key
+#    required: true
   gh_token:
     description: github auth secret
     required: false

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -22,6 +22,8 @@ inputs:
   gh_token:
     description: github auth secret
     required: false
+env:
+  USER: gha
 runs:
   using: composite
   steps:
@@ -40,6 +42,19 @@ runs:
         DPM_BIN_VERSION="$(cat dist/metadata.json | jq -r .version)"
         echo "DPM_BIN_VERSION=${DPM_BIN_VERSION}" >> "${GITHUB_ENV}"
       shell: bash -euo pipefail -c "source nix.source && exec bash {0}"
+#    - run: |
+#        if [ -z "${GH_TOKEN:-}" ] || [ -z "${GH_USER:-}" ]; then
+#          echo "Error: you need to set GH_TOKEN and GH_USER."
+#          exit 1
+#        fi
+#
+#        echo "$GH_TOKEN" | docker login ghcr.io -u "$USER" --password-stdin
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: gha
+        password: ${{ inputs.gh_token }}
     - name: dpm publish to ${{ inputs.repo }}
       run: |
         ref_name=${{ github.ref_name }}

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -22,8 +22,6 @@ inputs:
   gh_token:
     description: github auth secret
     required: false
-env:
-  USER: gha
 runs:
   using: composite
   steps:
@@ -43,14 +41,11 @@ runs:
         echo "DPM_BIN_VERSION=${DPM_BIN_VERSION}" >> "${GITHUB_ENV}"
       shell: bash -euo pipefail -c "source nix.source && exec bash {0}"
 #    - run: |
-#        if [ -z "${GH_TOKEN:-}" ] || [ -z "${GH_USER:-}" ]; then
-#          echo "Error: you need to set GH_TOKEN and GH_USER."
-#          exit 1
-#        fi
-#
 #        echo "$GH_TOKEN" | docker login ghcr.io -u "$USER" --password-stdin
     - name: Log in to GHCR
-      run: echo "${{ inputs.gh_token }}" | docker login ghcr.io -u gha --password-stdin
+      run: |
+        echo "${{ inputs.gh_token }}" | docker login ghcr.io -u gha --password-stdin
+      shell: bash -euo pipefail -c "source nix.source && exec bash {0}"
     - name: dpm publish to ${{ inputs.repo }}
       run: |
         ref_name=${{ github.ref_name }}

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -49,12 +49,8 @@ runs:
 #        fi
 #
 #        echo "$GH_TOKEN" | docker login ghcr.io -u "$USER" --password-stdin
-    - name: Log in to the Container registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: gha
-        password: ${{ inputs.gh_token }}
+    - name: Log in to GHCR
+      run: echo "${{ inputs.gh_token }}" | docker login ghcr.io -u gha --password-stdin
     - name: dpm publish to ${{ inputs.repo }}
       run: |
         ref_name=${{ github.ref_name }}

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -9,16 +9,11 @@ inputs:
   repo:
     type: string
     description: GAR repo to use when publishing
-    #default: "da-images/public-unstable"
     default: "temp"
   flags:
     type: string
     description: Additional flags to pass to goreleaser
     default: "--snapshot"
-#  key:
-#    type: string
-#    description: auth key
-#    required: true
   gh_token:
     description: github auth secret
     required: false
@@ -29,9 +24,6 @@ runs:
       with:
         fetch-depth: 0
     - uses: ./.github/actions/nix
-#    - uses: ./.github/actions/gcloud-login
-#      with:
-#        key: ${{ inputs.key }}
     - run: |
         export GIT_COMMIT_COUNT=$(git rev-list --count HEAD)
         goreleaser ${{ inputs.flags }}
@@ -40,11 +32,9 @@ runs:
         DPM_BIN_VERSION="$(cat dist/metadata.json | jq -r .version)"
         echo "DPM_BIN_VERSION=${DPM_BIN_VERSION}" >> "${GITHUB_ENV}"
       shell: bash -euo pipefail -c "source nix.source && exec bash {0}"
-#    - run: |
-#        echo "$GH_TOKEN" | docker login ghcr.io -u "$USER" --password-stdin
     - name: Log in to GHCR
       run: |
-        echo "${{ inputs.gh_token }}" | docker login ghcr.io -u gha --password-stdin
+        echo "${{ inputs.gh_token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
       shell: bash -euo pipefail -c "source nix.source && exec bash {0}"
     - name: dpm publish to ${{ inputs.repo }}
       run: |

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -4,11 +4,13 @@ inputs:
   registry:
     type: string
     description: GAR registry to use when publishing
-    default: "europe-docker.pkg.dev"
+#    default: "europe-docker.pkg.dev"
+    default: "ghcr.io/digital-asset"
   repo:
     type: string
     description: GAR repo to use when publishing
-    default: "da-images/public-unstable"
+    #default: "da-images/public-unstable"
+    default: "temp"
   flags:
     type: string
     description: Additional flags to pass to goreleaser
@@ -27,9 +29,9 @@ runs:
       with:
         fetch-depth: 0
     - uses: ./.github/actions/nix
-    - uses: ./.github/actions/gcloud-login
-      with:
-        key: ${{ inputs.key }}
+#    - uses: ./.github/actions/gcloud-login
+#      with:
+#        key: ${{ inputs.key }}
     - run: |
         export GIT_COMMIT_COUNT=$(git rev-list --count HEAD)
         goreleaser ${{ inputs.flags }}

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -8,14 +8,14 @@ inputs:
   repo:
     type: string
     description: GAR repo to use when publishing
-    default: "temp"
+    required: true
   flags:
     type: string
     description: Additional flags to pass to goreleaser
     default: "--snapshot"
   gh_token:
     description: github auth secret
-    required: false
+    required: true
 runs:
   using: composite
   steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,6 @@ jobs:
       - uses: ./.github/actions/release
         with:
           # todo - update once decided moved to CF
-          repo: "temp/unstable"
+          repo: "temp/temp"
           flags: "--snapshot"
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,6 @@ jobs:
         with:
           repo: stable
           flags: "--clean --skip=announce,publish,validate"
-#          key: ${{ secrets.DA_IMAGES }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   release-public-unstable:
@@ -92,5 +91,4 @@ jobs:
         with:
           repo: unstable
           flags: "--snapshot"
-#          key: ${{ secrets.DA_IMAGES }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ defaults:
 jobs:
   linux:
     runs-on: digital-asset-dpm
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/nix
@@ -39,6 +42,9 @@ jobs:
 
   windows:
     runs-on: windows-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,8 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release
         with:
-          repo: stable
+          # todo - update once decided moved to CF
+          repo: "temp"
           flags: "--clean --skip=announce,publish,validate"
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -89,6 +90,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/release
         with:
-          repo: unstable
+          # todo - update once decided moved to CF
+          repo: "temp/unstable"
           flags: "--snapshot"
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,9 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release
         with:
-          repo: da-images/public
+          repo: stable
           flags: "--clean --skip=announce,publish,validate"
-          key: ${{ secrets.DA_IMAGES }}
+#          key: ${{ secrets.DA_IMAGES }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   release-public-unstable:
@@ -84,6 +84,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/release
         with:
-          repo: da-images/public-unstable
+          repo: unstable
           flags: "--snapshot"
-          key: ${{ secrets.DA_IMAGES }}
+#          key: ${{ secrets.DA_IMAGES }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ local-build:
 	go test -v ./...
 	GIT_COMMIT_COUNT=$(shell git rev-list --count HEAD) goreleaser --snapshot --clean
 
-# Publish built artifacts to ghcr registry:
+# Publish built artifacts to registry:
 publish-release-to-gar: VERSION = $(shell cat dist/metadata.json | jq -r '.["version"]')
 publish-release-to-gar:
 	dist/${OS_TYPE}/${CPU_ARCH}/./dpm repo publish-dpm $(VERSION) $(ASSISTANT_ARGS) -g \

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ local-build:
 	go test -v ./...
 	GIT_COMMIT_COUNT=$(shell git rev-list --count HEAD) goreleaser --snapshot --clean
 
-# Publish built artifacts to GAR registry:
+# Publish built artifacts to ghcr registry:
 publish-release-to-gar: VERSION = $(shell cat dist/metadata.json | jq -r '.["version"]')
 publish-release-to-gar:
 	dist/${OS_TYPE}/${CPU_ARCH}/./dpm repo publish-dpm $(VERSION) $(ASSISTANT_ARGS) -g \


### PR DESCRIPTION
- Update inputs in release action / build workflow to use `ghcr.io/digital-asset`
- Publish unstable to `ghcr.io/digital-asset/temp/temp/components/dpm`
- Publish stable to `ghcr.io/digital-asset/temp/components/dpm`

[Link to temp](https://github.com/digital-asset/dpm/pkgs/container/temp%2Fcomponents%2Fdpm)