### PR TITLE
Add license exclusion flag

### DIFF
--- a/cmd/dpm/cmd/artifacts_test.go
+++ b/cmd/dpm/cmd/artifacts_test.go
@@ -39,6 +39,49 @@ func (suite *RepoSuite) TestPublishDar() {
 	require.NoError(t, cmd.Execute())
 }
 
+func (suite *RepoSuite) TestPublishLicenselessDar() {
+	t := suite.T()
+	t.Setenv(assistantconfig.DpmLockfileEnabledEnvVar, "true")
+
+	testutil.StartRegistry(t)
+
+	tmpDamlHome, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDamlHome)
+	destinationRegistry := os.Getenv(assistantconfig.OciRegistryEnvVar)
+	tmpDamlHome, err = os.MkdirTemp("", "")
+	require.NoError(t, err)
+	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDamlHome)
+
+	t.Run("succeed if exclude-license not present", func(t *testing.T) {
+		cmd := createStdTestRootCmd(t)
+		args := []string{
+			"publish", "dar", fmt.Sprintf("oci://%s/meep:1.2.3", destinationRegistry),
+			"-f", testutil.TestdataPath(t, "licenseless-dar"), "--exclude-license",
+		}
+
+		if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
+			args = append(args, "--insecure")
+		}
+
+		cmd.SetArgs(args)
+		require.NoError(t, cmd.Execute())
+	})
+
+	t.Run("err if exclude-license not present", func(t *testing.T) {
+		cmd := createStdTestRootCmd(t)
+		args := []string{
+			"publish", "dar", fmt.Sprintf("oci://%s/meep:1.2.3", destinationRegistry),
+			"-f", testutil.TestdataPath(t, "licenseless-dar"),
+		}
+		if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
+			args = append(args, "--insecure")
+		}
+		cmd.SetArgs(args)
+		require.Error(t, cmd.Execute())
+	})
+}
+
 func (suite *RepoSuite) TestPublishThirdPartyComponents() {
 	t := suite.T()
 	_, _ = testutil.StartRegistry(t)

--- a/cmd/dpm/cmd/publish/dar/dar.go
+++ b/cmd/dpm/cmd/publish/dar/dar.go
@@ -63,6 +63,7 @@ func Cmd() *cobra.Command {
 				AuthFilePath:   c.RegistryAuth,
 				Insecure:       c.Insecure,
 				ExtraTags:      c.ExtraTags,
+				ExcludeLicense: c.ExcludeLicense,
 			}
 			return publishdar.New(publishDarConfig, cmd).PublishDar(cmd.Context())
 		},
@@ -71,7 +72,7 @@ func Cmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&c.DryRun, "dry-run", "d", false, "don't actually push to the registry")
 	cmd.Flags().BoolVarP(&c.IncludeGitInfo, "include-git-info", "g", false, "include git info as annotations on the published manifest")
 	cmd.Flags().StringToStringVarP(&c.Annotations, "annotations", "a", map[string]string{}, "annotations to include in the published OCI artifact")
-
+	cmd.Flags().BoolVar(&c.ExcludeLicense, "exclude-license", false, "FOR NON-PRODUCTION USE: disable license file requirement for DAR publishing")
 	cmd.Flags().StringVarP(&c.File, "file", "f", "", `REQUIRED path to the dar file to publish`)
 	cmd.MarkFlagRequired(publishcmd.FileFlagName)
 

--- a/pkg/publishcmd/publishcmd.go
+++ b/pkg/publishcmd/publishcmd.go
@@ -32,6 +32,7 @@ type PublishDarCmd struct {
 	Annotations            map[string]string
 	File                   string
 	ExtraTags              []string
+	ExcludeLicense         bool
 
 	Insecure     bool
 	Registry     string

--- a/pkg/publishdar/publishdar.go
+++ b/pkg/publishdar/publishdar.go
@@ -36,6 +36,7 @@ type DarConfig struct {
 	DryRun, IncludeGitInfo bool
 	Annotations            map[string]string
 	ExtraTags              []string
+	ExcludeLicense         bool
 
 	Destination  *publish.Destination
 	AuthFilePath string
@@ -55,6 +56,9 @@ func (p *DarPublisher) PublishDar(ctx context.Context) (err error) {
 	var pushOp *darpusher.DarPushOperation
 	if assistantconfig.DpmLockfileEnabled() {
 		pushOp, err = p.prepareDar(ctx, p.config.File)
+		if err != nil {
+			return err
+		}
 
 		if p.config.DryRun {
 			p.printer.Println("Skipping push due to --dry-run")
@@ -99,9 +103,13 @@ func (p *DarPublisher) PublishDar(ctx context.Context) (err error) {
 }
 
 func (p *DarPublisher) prepareDar(ctx context.Context, dir string) (*darpusher.DarPushOperation, error) {
-	p.printer.Printf("📦 Checking %q includes license file...\n", dir)
-	if err := checkHasLicense(dir); err != nil {
-		return nil, err
+	if p.config.ExcludeLicense {
+		p.printer.Println("Skipping license file check due to --exclude-license flag being set, this is NOT recommended for production use")
+	} else {
+		p.printer.Printf("📦 Checking %q includes license file...\n", dir)
+		if err := checkHasLicense(dir); err != nil {
+			return nil, err
+		}
 	}
 	p.printer.Printf("License file included ✅\n")
 	p.printer.Println()

--- a/pkg/publishdar/publishdar.go
+++ b/pkg/publishdar/publishdar.go
@@ -104,7 +104,7 @@ func (p *DarPublisher) PublishDar(ctx context.Context) (err error) {
 
 func (p *DarPublisher) prepareDar(ctx context.Context, dir string) (*darpusher.DarPushOperation, error) {
 	if p.config.ExcludeLicense {
-		p.printer.Println("Skipping license file check due to --exclude-license flag being set, this is NOT recommended for production use")
+		p.printer.Println("FOR TESTING ONLY: Skipping license file check due to --exclude-license flag being set")
 	} else {
 		p.printer.Printf("📦 Checking %q includes license file...\n", dir)
 		if err := checkHasLicense(dir); err != nil {

--- a/pkg/testutil/testdata/licenseless-dar/dar.yaml
+++ b/pkg/testutil/testdata/licenseless-dar/dar.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Dar
+spec:
+  path: ./meep.dar

--- a/pkg/testutil/testdata/licenseless-dar/meep.dar
+++ b/pkg/testutil/testdata/licenseless-dar/meep.dar
@@ -1,0 +1,1 @@
+haha not a real dar :p


### PR DESCRIPTION
Add an `exclude-license` flag option with clear warning on non-production use, added test and update command to err out 