### PR TITLE
:turtle:  resolve dars

### DIFF
--- a/cmd/dpm/cmd/artifacts_test.go
+++ b/cmd/dpm/cmd/artifacts_test.go
@@ -20,17 +20,37 @@ func (suite *RepoSuite) TestPublishDar() {
 	require.NoError(t, err)
 	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDamlHome)
 
-	testutil.StartRegistry(t)
+	testutil.StartDpmRegistry(t)
 	destinationRegistry := os.Getenv(assistantconfig.OciRegistryEnvVar)
 
 	pushDar(t, fmt.Sprintf("oci://%s/meep:1.2.3", destinationRegistry))
+}
+
+func pushDar(t *testing.T, uri string, extraTags ...string) {
+	t.Run("push dar", func(t *testing.T) {
+		cmd := createStdTestRootCmd(t)
+		args := []string{
+			"publish", "dar", uri,
+			"-f", testutil.TestdataPath(t, "test-dar"),
+		}
+
+		for _, t := range extraTags {
+			args = append(args, "--extra-tags", t)
+		}
+
+		if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
+			args = append(args, "--insecure")
+		}
+		cmd.SetArgs(args)
+		require.NoError(t, cmd.Execute())
+	})
 }
 
 func (suite *RepoSuite) TestPublishLicenselessDar() {
 	t := suite.T()
 	t.Setenv(assistantconfig.DpmLockfileEnabledEnvVar, "true")
 
-	testutil.StartRegistry(t)
+	testutil.StartDpmRegistry(t)
 
 	tmpDamlHome, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
@@ -71,7 +91,7 @@ func (suite *RepoSuite) TestPublishLicenselessDar() {
 
 func (suite *RepoSuite) TestPublishThirdPartyComponents() {
 	t := suite.T()
-	_, _ = testutil.StartRegistry(t)
+	_, _ = testutil.StartDpmRegistry(t)
 	uri := fmt.Sprintf("%s/x/y/z", os.Getenv(assistantconfig.OciRegistryEnvVar))
 
 	args := []string{"publish", "component", fmt.Sprintf("oci://%s/meep:1.2.3", uri),
@@ -101,7 +121,7 @@ func (suite *RepoSuite) TestPublishThirdPartyComponents() {
 
 func (suite *RepoSuite) TestComponentTags() {
 	t := suite.T()
-	_, reg := testutil.StartRegistry(t)
+	_, reg := testutil.StartDpmRegistry(t)
 
 	args := testutil.PushComponentUri(reg, fmt.Sprintf("%s/%s:%s", "foo/bar", "meep", "1.2.3"), testutil.TestdataPath(t, "meepy-component", testutil.OS))
 	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
@@ -125,7 +145,7 @@ func (suite *RepoSuite) TestComponentTags() {
 func (suite *RepoSuite) TestDarTags() {
 	t := suite.T()
 	t.Setenv(assistantconfig.DpmLockfileEnabledEnvVar, "true")
-	_, reg := testutil.StartRegistry(t)
+	_, reg := testutil.StartDpmRegistry(t)
 
 	args := testutil.PushDarUri(reg, fmt.Sprintf("%s/%s:%s", "foo/bar", "meep", "1.2.3"), testutil.TestdataPath(t, "test-dar"))
 	require.NoError(t, createStdTestRootCmd(t, args...).Execute())

--- a/cmd/dpm/cmd/artifacts_test.go
+++ b/cmd/dpm/cmd/artifacts_test.go
@@ -16,27 +16,14 @@ import (
 func (suite *RepoSuite) TestPublishDar() {
 	t := suite.T()
 
-	testutil.StartRegistry(t)
-
 	tmpDamlHome, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDamlHome)
+
+	testutil.StartRegistry(t)
 	destinationRegistry := os.Getenv(assistantconfig.OciRegistryEnvVar)
-	tmpDamlHome, err = os.MkdirTemp("", "")
-	require.NoError(t, err)
-	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDamlHome)
 
-	cmd := createStdTestRootCmd(t)
-	args := []string{
-		"publish", "dar", fmt.Sprintf("oci://%s/meep:1.2.3", destinationRegistry),
-		"-f", testutil.TestdataPath(t, "test-dar"),
-	}
-
-	if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
-		args = append(args, "--insecure")
-	}
-	cmd.SetArgs(args)
-	require.NoError(t, cmd.Execute())
+	pushDar(t, fmt.Sprintf("oci://%s/meep:1.2.3", destinationRegistry))
 }
 
 func (suite *RepoSuite) TestPublishLicenselessDar() {

--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -172,7 +172,7 @@ func (suite *MainSuite) TestResolveWithDpmSdkVersionEnvVar() {
 	installSdk(t, []string{someSdkVersion})
 
 	// prepare and install another sdk
-	_, reg := testutil.StartRegistry(t)
+	_, reg := testutil.StartDpmRegistry(t)
 	anotherSdkVersion := "1.2.3"
 	anotherSdkAssembly := createAssembly(t, anotherSdkVersion, "4.5.6")
 	testutil.PushAssembly(t, ctx, sdkmanifest.OpenSource, reg, anotherSdkVersion, anotherSdkAssembly)
@@ -345,7 +345,7 @@ func (suite *MainSuite) TestComponentDependencyPaths() {
 func (suite *MainSuite) TestComponentPublish() {
 	t := suite.T()
 	ctx := testutil.Context(t)
-	client, _ := testutil.StartRegistry(t)
+	client, _ := testutil.StartDpmRegistry(t)
 
 	publish := func(t *testing.T, version string) {
 		args := []string{"repo", "publish-component", "meepy-repo", version,
@@ -463,7 +463,7 @@ func (suite *MainSuite) TestSdkInstallCommand() {
 
 func installFloatySdk(t *testing.T, version string, floatyTag string) {
 	ctx := testutil.Context(t)
-	_, reg := testutil.StartRegistry(t)
+	_, reg := testutil.StartDpmRegistry(t)
 
 	// Push assembly for each version
 	testutil.PushAssembly(t, ctx, sdkmanifest.OpenSource, reg, version, testutil.TestdataPath(t, "remote-components.yaml"))
@@ -496,7 +496,7 @@ func installFloatySdk(t *testing.T, version string, floatyTag string) {
 
 func installSdk(t *testing.T, versions []string) {
 	ctx := testutil.Context(t)
-	_, reg := testutil.StartRegistry(t)
+	_, reg := testutil.StartDpmRegistry(t)
 
 	// Push assembly for each version
 	for _, v := range versions {
@@ -537,7 +537,7 @@ func installSdk(t *testing.T, versions []string) {
 
 func installSdkForComponent(t *testing.T, sdkVersion, componentName, componentVersion string) {
 	ctx := testutil.Context(t)
-	_, reg := testutil.StartRegistry(t)
+	_, reg := testutil.StartDpmRegistry(t)
 
 	assert.NotEmpty(t, os.Getenv(assistantconfig.DpmHomeEnvVar), "must set DPM_HOME to use installSdkForComponent")
 
@@ -747,8 +747,8 @@ func (suite *MainSuite) TestInstallPackageMultipleRegistries() {
 	t.Setenv(assistantconfig.DpmHomeEnvVar, dpmHome)
 
 	ctx := testutil.Context(t)
-	_, reg := testutil.StartRegistry(t)
-	_, altReg := testutil.StartRegistry(t)
+	_, reg := testutil.StartDpmRegistry(t)
+	_, altReg := testutil.StartDpmRegistry(t)
 
 	regURL := strings.TrimPrefix(reg.URL, "http://")
 	altURL := strings.TrimPrefix(altReg.URL, "http://")
@@ -798,7 +798,7 @@ func (suite *MainSuite) TestInstallPackageMultipleRegistries() {
 func (suite *MainSuite) TestSdkVersionCommand() {
 	t := suite.T()
 	ctx := testutil.Context(t)
-	_, reg := testutil.StartRegistry(t)
+	_, reg := testutil.StartDpmRegistry(t)
 
 	sdkVersions := []string{someSdkVersion, "2.0.0-alpha", "1.0.0", "1.0.1", "3.0.0", "1.1.0"}
 	sorted := []string{

--- a/cmd/dpm/cmd/assistant_upgrade_test.go
+++ b/cmd/dpm/cmd/assistant_upgrade_test.go
@@ -4,13 +4,14 @@
 package cmd
 
 import (
-	"daml.com/x/assistant/pkg/assembler"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"daml.com/x/assistant/pkg/assembler"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/sdkmanifest"
@@ -26,7 +27,7 @@ import (
 func (suite *MainSuite) TestAssistantUpgrade() {
 	t := suite.T()
 	ctx := testutil.Context(t)
-	_, reg := testutil.StartRegistry(t)
+	_, reg := testutil.StartDpmRegistry(t)
 
 	sdkVersion := "0.0.1-whatever"
 	newerSdkVersion, err := semver.NewVersion("0.0.3")

--- a/cmd/dpm/cmd/component_overlay_test.go
+++ b/cmd/dpm/cmd/component_overlay_test.go
@@ -152,7 +152,7 @@ func (suite *MainSuite) TestComponentOverlay() {
 
 	t.Setenv("PATH", testutil.TestdataPath(t, "fake-java", testutil.OS)+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	_, reg := testutil.StartRegistry(t)
+	_, reg := testutil.StartDpmRegistry(t)
 
 	testutil.PushGenericComponentWithCommand(t, reg, "foo", "0.0.1", "foo")
 	testutil.PushGenericComponentWithCommand(t, reg, "foo", "0.0.2", "foo")

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2017-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"daml.com/x/assistant/pkg/assistantconfig"
+	"daml.com/x/assistant/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *MainSuite) TestDars() {
+	t := suite.T()
+
+	testutil.StartRegistry(t)
+
+	tmpDamlHome, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDamlHome)
+	destinationRegistry := os.Getenv(assistantconfig.OciRegistryEnvVar)
+	tmpDamlHome, err = os.MkdirTemp("", "")
+	require.NoError(t, err)
+	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDamlHome)
+
+	t.Setenv("TEST_DPM_REGISTRY", destinationRegistry)
+	t.Setenv(assistantconfig.DpmDarsEnabledEnvVar, "true")
+	pushDar(t, fmt.Sprintf("oci://%s/some/dars/foo:1.2.3", destinationRegistry))
+	pushDar(t, fmt.Sprintf("oci://%s/some/dars/n/stuff/foo:4.5.6", destinationRegistry))
+	pushDar(t, fmt.Sprintf("oci://%s/some/more/official/dars/foo:7.8.9", destinationRegistry))
+
+	t.Chdir(testutil.TestdataPath(t, "daml-dependencies"))
+	res := runResolveCommand(t)
+	assert.Nil(t, res)
+
+}
+
+func pushDar(t *testing.T, uri string, extraTags ...string) {
+	cmd := createStdTestRootCmd(t)
+	args := []string{
+		"publish", "dar", uri,
+		"-f", testutil.TestdataPath(t, "test-dar"),
+	}
+
+	for _, t := range extraTags {
+		args = append(args, "--extra-tags", t)
+	}
+
+	if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
+		args = append(args, "--insecure")
+	}
+	cmd.SetArgs(args)
+	require.NoError(t, cmd.Execute())
+
+}

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -16,50 +15,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (suite *MainSuite) TestDars() {
+func (suite *MainSuite) TestPullingAndResolutionOfDarDependencies() {
 	t := suite.T()
 
-	tmpDamlHome, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDamlHome)
-
-	testutil.StartRegistry(t)
-	destinationRegistry := os.Getenv(assistantconfig.OciRegistryEnvVar)
-
-	t.Setenv("TEST_DPM_REGISTRY", destinationRegistry)
+	// enable feature flag
 	t.Setenv(assistantconfig.DpmDarsEnabledEnvVar, "true")
 
-	pushDar(t, fmt.Sprintf("oci://%s/some/dars/foo:1.2.3", destinationRegistry))
-	pushDar(t, fmt.Sprintf("oci://%s/some/dars/n/stuff/foo:4.5.6", destinationRegistry))
-	pushDar(t, fmt.Sprintf("oci://%s/some/more/official/dars/foo:7.8.9", destinationRegistry))
+	// setup
+	tmpDpmHome, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDpmHome)
 
-	t.Run("dar resolution", func(t *testing.T) {
+	t.Run("dar resolution contains data-dependencies and dependencies", func(t *testing.T) {
 		t.Chdir(testutil.TestdataPath(t, "daml-dependencies"))
 		res := lo.Values(runResolveCommand(t).Packages)[0]
+
+		assert.Contains(t, res.Errors[0].Cause, "oci://")
+
+		assert.Len(t, res.ResolvedDataDependencies, 4)
+		assert.Contains(t)
 
 		assert.Len(t, res.Errors, 3)
 		for _, err := range res.Errors {
 			assert.Equal(t, err.Code, resolutionerrors.DarNotInstalled)
 		}
-	})
-}
-
-func pushDar(t *testing.T, uri string, extraTags ...string) {
-	t.Run("push dar", func(t *testing.T) {
-		cmd := createStdTestRootCmd(t)
-		args := []string{
-			"publish", "dar", uri,
-			"-f", testutil.TestdataPath(t, "test-dar"),
-		}
-
-		for _, t := range extraTags {
-			args = append(args, "--extra-tags", t)
-		}
-
-		if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
-			args = append(args, "--insecure")
-		}
-		cmd.SetArgs(args)
-		require.NoError(t, cmd.Execute())
 	})
 }

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -28,34 +28,38 @@ func (suite *MainSuite) TestDars() {
 
 	t.Setenv("TEST_DPM_REGISTRY", destinationRegistry)
 	t.Setenv(assistantconfig.DpmDarsEnabledEnvVar, "true")
+
 	pushDar(t, fmt.Sprintf("oci://%s/some/dars/foo:1.2.3", destinationRegistry))
 	pushDar(t, fmt.Sprintf("oci://%s/some/dars/n/stuff/foo:4.5.6", destinationRegistry))
 	pushDar(t, fmt.Sprintf("oci://%s/some/more/official/dars/foo:7.8.9", destinationRegistry))
 
-	t.Chdir(testutil.TestdataPath(t, "daml-dependencies"))
-	res := lo.Values(runResolveCommand(t).Packages)[0]
+	t.Run("dar resolution", func(t *testing.T) {
+		t.Chdir(testutil.TestdataPath(t, "daml-dependencies"))
+		res := lo.Values(runResolveCommand(t).Packages)[0]
 
-	assert.Len(t, res.Errors, 3)
-	for _, err := range res.Errors {
-		assert.Equal(t, err.Code, resolutionerrors.DarNotInstalled)
-	}
+		assert.Len(t, res.Errors, 3)
+		for _, err := range res.Errors {
+			assert.Equal(t, err.Code, resolutionerrors.DarNotInstalled)
+		}
+	})
 }
 
 func pushDar(t *testing.T, uri string, extraTags ...string) {
-	cmd := createStdTestRootCmd(t)
-	args := []string{
-		"publish", "dar", uri,
-		"-f", testutil.TestdataPath(t, "test-dar"),
-	}
+	t.Run("push dar", func(t *testing.T) {
+		cmd := createStdTestRootCmd(t)
+		args := []string{
+			"publish", "dar", uri,
+			"-f", testutil.TestdataPath(t, "test-dar"),
+		}
 
-	for _, t := range extraTags {
-		args = append(args, "--extra-tags", t)
-	}
+		for _, t := range extraTags {
+			args = append(args, "--extra-tags", t)
+		}
 
-	if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
-		args = append(args, "--insecure")
-	}
-	cmd.SetArgs(args)
-	require.NoError(t, cmd.Execute())
-
+		if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
+			args = append(args, "--insecure")
+		}
+		cmd.SetArgs(args)
+		require.NoError(t, cmd.Execute())
+	})
 }

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -8,8 +8,10 @@ import (
 	"os"
 	"testing"
 
+	"daml.com/x/assistant/cmd/dpm/cmd/resolve/resolutionerrors"
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/testutil"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,15 +19,12 @@ import (
 func (suite *MainSuite) TestDars() {
 	t := suite.T()
 
-	testutil.StartRegistry(t)
-
 	tmpDamlHome, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDamlHome)
+
+	testutil.StartRegistry(t)
 	destinationRegistry := os.Getenv(assistantconfig.OciRegistryEnvVar)
-	tmpDamlHome, err = os.MkdirTemp("", "")
-	require.NoError(t, err)
-	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDamlHome)
 
 	t.Setenv("TEST_DPM_REGISTRY", destinationRegistry)
 	t.Setenv(assistantconfig.DpmDarsEnabledEnvVar, "true")
@@ -34,9 +33,12 @@ func (suite *MainSuite) TestDars() {
 	pushDar(t, fmt.Sprintf("oci://%s/some/more/official/dars/foo:7.8.9", destinationRegistry))
 
 	t.Chdir(testutil.TestdataPath(t, "daml-dependencies"))
-	res := runResolveCommand(t)
-	assert.Nil(t, res)
+	res := lo.Values(runResolveCommand(t).Packages)[0]
 
+	assert.Len(t, res.Errors, 3)
+	for _, err := range res.Errors {
+		assert.Equal(t, err.Code, resolutionerrors.DarNotInstalled)
+	}
 }
 
 func pushDar(t *testing.T, uri string, extraTags ...string) {

--- a/cmd/dpm/cmd/lockfile_test.go
+++ b/cmd/dpm/cmd/lockfile_test.go
@@ -17,14 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func get(t *testing.T, lock *packagelock.PackageLock, s string) *packagelock.Dar {
-	d, ok := lo.Find(lock.Dars, func(d *packagelock.Dar) bool {
-		return d.URI.String() == s
-	})
-	require.Truef(t, ok, "expected %q dar is missing in lockfile", s)
-	return d
-}
-
 func (suite *MainSuite) TestLockfileUpdate() {
 	t := suite.T()
 	ctx := t.Context()
@@ -117,6 +109,14 @@ func (suite *MainSuite) TestLockfileUpdate() {
 		require.NoError(t, err)
 		assert.Contains(t, string(dar), "haha not a real dar")
 	})
+}
+
+func get(t *testing.T, lock *packagelock.PackageLock, s string) *packagelock.Dar {
+	d, ok := lo.Find(lock.Dars, func(d *packagelock.Dar) bool {
+		return d.URI.String() == s
+	})
+	require.Truef(t, ok, "expected %q dar is missing in lockfile", s)
+	return d
 }
 
 func (suite *MainSuite) TestLockfileFieldOverridesExhaustive() {

--- a/cmd/dpm/cmd/lockfile_test.go
+++ b/cmd/dpm/cmd/lockfile_test.go
@@ -34,7 +34,7 @@ func (suite *MainSuite) TestLockfileUpdate() {
 	tmpDamlHome := t.TempDir()
 	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDamlHome)
 
-	_, reg := testutil.StartRegistry(t)
+	_, reg := testutil.StartDpmRegistry(t)
 	multiPackageDir := testutil.TestdataPath(t, "multi-package-simple")
 	t.Setenv(assistantconfig.DamlMultiPackageEnvVar, multiPackageDir)
 

--- a/cmd/dpm/cmd/lockfile_test.go
+++ b/cmd/dpm/cmd/lockfile_test.go
@@ -17,6 +17,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func get(t *testing.T, lock *packagelock.PackageLock, s string) *packagelock.Dar {
+	d, ok := lo.Find(lock.Dars, func(d *packagelock.Dar) bool {
+		return d.URI.String() == s
+	})
+	require.Truef(t, ok, "expected %q dar is missing in lockfile", s)
+	return d
+}
+
 func (suite *MainSuite) TestLockfileUpdate() {
 	t := suite.T()
 	ctx := t.Context()
@@ -109,14 +117,6 @@ func (suite *MainSuite) TestLockfileUpdate() {
 		require.NoError(t, err)
 		assert.Contains(t, string(dar), "haha not a real dar")
 	})
-}
-
-func get(t *testing.T, lock *packagelock.PackageLock, s string) *packagelock.Dar {
-	d, ok := lo.Find(lock.Dars, func(d *packagelock.Dar) bool {
-		return d.URI.String() == s
-	})
-	require.Truef(t, ok, "expected %q dar is missing in lockfile", s)
-	return d
 }
 
 func (suite *MainSuite) TestLockfileFieldOverridesExhaustive() {

--- a/cmd/dpm/cmd/repo_test.go
+++ b/cmd/dpm/cmd/repo_test.go
@@ -46,7 +46,7 @@ func (suite *RepoSuite) TestRepoCreateTarball() {
 	t := suite.T()
 	// the commands under test should work fully without requiring Edition env var to be set
 	os.Unsetenv(assistantconfig.EditionEnvVar)
-	testutil.StartRegistry(t)
+	testutil.StartDpmRegistry(t)
 	bundlePath, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
@@ -119,7 +119,7 @@ func (suite *RepoSuite) TestRepoCreateTarball() {
 func (suite *RepoSuite) TestRepoPublishAssembly() {
 	t := suite.T()
 
-	client, _ := testutil.StartRegistry(t)
+	client, _ := testutil.StartDpmRegistry(t)
 
 	tmpDamlHome, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
@@ -184,7 +184,7 @@ func testPlatformSpecificSdk(t *testing.T, damlHome string) {
 
 func (suite *RepoSuite) TestResolveLatest() {
 	t := suite.T()
-	testutil.StartRegistry(t)
+	testutil.StartDpmRegistry(t)
 
 	tmpDamlHome, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
@@ -322,7 +322,7 @@ func (suite *RepoSuite) TestOciAnnotations() {
 	}
 
 	t.Run("publishing of new and legacy annotations", func(t *testing.T) {
-		_, reg := testutil.StartRegistry(t)
+		_, reg := testutil.StartDpmRegistry(t)
 		testPushAndPull(t)
 		assertAllAnnotation(t, reg, IncludesLegacy)
 	})
@@ -330,7 +330,7 @@ func (suite *RepoSuite) TestOciAnnotations() {
 	t.Run("missing legacy on the read side is ok", func(t *testing.T) {
 		t.Setenv(ociconsts.SkipLegacyOciAnnotationsEnvVar, "true")
 
-		_, reg := testutil.StartRegistry(t)
+		_, reg := testutil.StartDpmRegistry(t)
 		testPushAndPull(t)
 		assertAllAnnotation(t, reg, NoLegacy)
 	})
@@ -339,7 +339,7 @@ func (suite *RepoSuite) TestOciAnnotations() {
 func (suite *RepoSuite) TestPromoteComponents() {
 	t := suite.T()
 
-	testutil.StartRegistry(t)
+	testutil.StartDpmRegistry(t)
 	sourceRegistry := os.Getenv(assistantconfig.OciRegistryEnvVar)
 
 	tmpDamlHome, err := os.MkdirTemp("", "")
@@ -348,7 +348,7 @@ func (suite *RepoSuite) TestPromoteComponents() {
 
 	publishComponents(t)
 
-	testutil.StartRegistry(t)
+	testutil.StartDpmRegistry(t)
 	destinationRegistry := os.Getenv(assistantconfig.OciRegistryEnvVar)
 
 	tmpDamlHome, err = os.MkdirTemp("", "")

--- a/cmd/dpm/cmd/resolve/resolutionerrors/resolutionerrors.go
+++ b/cmd/dpm/cmd/resolve/resolutionerrors/resolutionerrors.go
@@ -11,6 +11,7 @@ const (
 	DamlYamlNotFound  = "DAML_YAML_NOT_FOUND"
 	UnknownError      = "UNKNOWN_ERROR"
 	OutdatedLockfile  = "OUTDATED_DPM_LOCK"
+	DarNotInstalled   = "DAR_NOT_INSTALLED"
 )
 
 type ResolutionError struct {
@@ -92,15 +93,36 @@ func NewUnknownError(cause error) *ResolutionError {
 	}
 }
 
-func Standardize(err error) *ResolutionError {
+func NewDarNotInstalled(cause error) *ResolutionError {
+	return &ResolutionError{
+		Code:  DarNotInstalled,
+		Cause: cause,
+	}
+}
+
+func Standardize(err error) []*ResolutionError {
 	if err == nil {
 		return nil
 	}
 
-	var resErr *ResolutionError
-	if errors.As(err, &resErr) {
-		return resErr
+	type joinErr interface {
+		Unwrap() []error
 	}
 
-	return NewUnknownError(err)
+	if joined, ok := err.(joinErr); ok {
+		var out []*ResolutionError
+
+		for _, e := range joined.Unwrap() {
+			out = append(out, Standardize(e)...)
+		}
+
+		return out
+	}
+
+	var resErr *ResolutionError
+	if errors.As(err, &resErr) {
+		return []*ResolutionError{resErr}
+	}
+
+	return []*ResolutionError{NewUnknownError(err)}
 }

--- a/pkg/assistantconfig/config.go
+++ b/pkg/assistantconfig/config.go
@@ -376,3 +376,11 @@ func GetAssistantUserAgent() string {
 func DpmLockfileEnabled() bool {
 	return os.Getenv(DpmLockfileEnabledEnvVar) == "true"
 }
+
+func DpmDarsEnabled() bool {
+	return os.Getenv(DpmDarsEnabledEnvVar) == "true"
+}
+
+func (c *Config) CachePathForDar(registry, repository, version string) string {
+	return filepath.Join(c.CachePath, "dars", utils.UrlToFilePath(fmt.Sprintf("%s/%s", registry, repository)), version)
+}

--- a/pkg/assistantconfig/envvars.go
+++ b/pkg/assistantconfig/envvars.go
@@ -66,4 +66,5 @@ const (
 	DpmSdkVersionEnvVar = "DPM_SDK_VERSION"
 
 	DpmLockfileEnabledEnvVar = "DPM_LOCKFILE_ENABLED"
+	DpmDarsEnabledEnvVar     = "DPM_DARS_ENABLED"
 )

--- a/pkg/damlpackage/damlproject.go
+++ b/pkg/damlpackage/damlproject.go
@@ -76,7 +76,7 @@ func ReadFromContents(contents []byte) (*DamlPackage, error) {
 		obj.DeprecatedOverrideComponents = nil
 	}
 
-	if assistantconfig.DpmDarsEnabled() {
+	if assistantconfig.DpmDarsEnabled() || assistantconfig.DpmLockfileEnabled() {
 		_, defaultLocation, err := obj.ArtifactLocations.GetDefaultLocation()
 		if err != nil {
 			return nil, fmt.Errorf("invalid artifact locations: %w", err)

--- a/pkg/damlpackage/damlproject.go
+++ b/pkg/damlpackage/damlproject.go
@@ -14,6 +14,11 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
+type ParsedDarDependencies struct {
+	Dependencies     map[string]*ParsedDarDependency
+	DataDependencies map[string]*ParsedDarDependency
+}
+
 type DamlPackage struct {
 	SdkVersion string `yaml:"sdk-version"`
 
@@ -23,9 +28,10 @@ type DamlPackage struct {
 	// deprecated in favor of Components
 	DeprecatedOverrideComponents map[string]*sdkmanifest.Component `yaml:"override-components,omitempty"`
 
-	Dependencies         []string                       `yaml:"dependencies,omitempty"`
-	ArtifactLocations    ArtifactLocations              `yaml:"artifact-locations,omitempty"`
-	ResolvedDependencies map[string]*ResolvedDependency `yaml:"-"`
+	Dependencies          []string               `yaml:"dependencies,omitempty"`
+	DataDependencies      []string               `yaml:"data-dependencies,omitempty"`
+	ArtifactLocations     ArtifactLocations      `yaml:"artifact-locations,omitempty"`
+	ParsedDarDependencies *ParsedDarDependencies `yaml:"-"`
 }
 
 func Read(filePath string) (*DamlPackage, error) {
@@ -70,16 +76,23 @@ func ReadFromContents(contents []byte) (*DamlPackage, error) {
 		obj.DeprecatedOverrideComponents = nil
 	}
 
-	if assistantconfig.DpmLockfileEnabled() {
+	if assistantconfig.DpmDarsEnabled() {
 		_, defaultLocation, err := obj.ArtifactLocations.GetDefaultLocation()
 		if err != nil {
 			return nil, fmt.Errorf("invalid artifact locations: %w", err)
 		}
 
+		obj.ParsedDarDependencies = &ParsedDarDependencies{}
 		if len(obj.Dependencies) > 0 {
-			obj.ResolvedDependencies, err = obj.computeResolvedDependencies(defaultLocation)
+			obj.ParsedDarDependencies.Dependencies, err = parseLocations(obj.Dependencies, obj.ArtifactLocations, defaultLocation)
 			if err != nil {
-				return nil, fmt.Errorf("failed to resolve provided dependencies: %w", err)
+				return nil, fmt.Errorf("failed to parse provided dependencies: %w", err)
+			}
+		}
+		if len(obj.DataDependencies) > 0 {
+			obj.ParsedDarDependencies.DataDependencies, err = parseLocations(obj.DataDependencies, obj.ArtifactLocations, defaultLocation)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse provided data-dependencies: %w", err)
 			}
 		}
 	}

--- a/pkg/damlpackage/damlproject_test.go
+++ b/pkg/damlpackage/damlproject_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDarDependencies(t *testing.T) {
 	t.Setenv(assistantconfig.DpmLockfileEnabledEnvVar, "true")
-	t.Setenv("TEST_DPM_REGISTRY_PORT", "5000")
+	t.Setenv("TEST_DPM_REGISTRY", "localhost:5000")
 	p, err := Read(testutil.TestdataPath(t, "daml-dependencies", "daml.yaml"))
 	require.NoError(t, err)
 

--- a/pkg/damlpackage/damlproject_test.go
+++ b/pkg/damlpackage/damlproject_test.go
@@ -21,15 +21,15 @@ func TestDarDependencies(t *testing.T) {
 	assert.True(t, p.ArtifactLocations["@digital-asset"].Default)
 	assert.False(t, p.ArtifactLocations["@my-location"].Default)
 
-	assert.Len(t, p.ResolvedDependencies, len(p.Dependencies))
+	assert.Len(t, p.ParsedDarDependencies.Dependencies, len(p.Dependencies))
 
-	assert.NotNil(t, p.ResolvedDependencies["foo:devnet"].Location)
-	assert.NotNil(t, p.ResolvedDependencies["@my-location/foo:4.5.6"].Location)
-	assert.Nil(t, p.ResolvedDependencies["oci://localhost:5000/some/dars/foo:1.2.3"].Location)
+	assert.NotNil(t, p.ParsedDarDependencies.Dependencies["foo:devnet"].Location)
+	assert.NotNil(t, p.ParsedDarDependencies.Dependencies["@my-location/foo:4.5.6"].Location)
+	assert.Nil(t, p.ParsedDarDependencies.Dependencies["oci://localhost:5000/some/dars/foo:1.2.3"].Location)
 
-	assert.Equal(t, p.ResolvedDependencies["foo:devnet"].FullUrl.String(), "oci://localhost:5000/more/official/dars/foo:devnet")
-	assert.Equal(t, p.ResolvedDependencies["oci://localhost:5000/some/dars/foo:1.2.3"].FullUrl.String(), "oci://localhost:5000/some/dars/foo:1.2.3")
-	assert.Equal(t, p.ResolvedDependencies["@my-location/foo:4.5.6"].FullUrl.String(), "oci://localhost:5000/some/dars/n/stuff/foo:4.5.6")
+	assert.Equal(t, p.ParsedDarDependencies.Dependencies["foo:devnet"].FullUrl.String(), "oci://localhost:5000/more/official/dars/foo:devnet")
+	assert.Equal(t, p.ParsedDarDependencies.Dependencies["oci://localhost:5000/some/dars/foo:1.2.3"].FullUrl.String(), "oci://localhost:5000/some/dars/foo:1.2.3")
+	assert.Equal(t, p.ParsedDarDependencies.Dependencies["@my-location/foo:4.5.6"].FullUrl.String(), "oci://localhost:5000/some/dars/n/stuff/foo:4.5.6")
 
 }
 

--- a/pkg/damlpackage/locations.go
+++ b/pkg/damlpackage/locations.go
@@ -25,7 +25,7 @@ type ArtifactLocation struct {
 	Client *auth.Client
 }
 
-type ResolvedDependency struct {
+type ParsedDarDependency struct {
 	// the fully-qualified URL for the artifact e.g. oci://example.com/foo/bar/baz:1.2.3
 	FullUrl *url.URL
 
@@ -33,7 +33,7 @@ type ResolvedDependency struct {
 	Location *ArtifactLocation
 }
 
-func (d *ResolvedDependency) GetOciRepo() (*remote.Repository, *registry.Reference, error) {
+func (d *ParsedDarDependency) GetOciRepo() (*remote.Repository, *registry.Reference, error) {
 	ref, err := registry.ParseReference(strings.TrimPrefix(d.FullUrl.String(), "oci://"))
 	if err != nil {
 		return nil, nil, err
@@ -78,19 +78,19 @@ func (ls ArtifactLocations) GetDefaultLocation() (name string, location *Artifac
 	return
 }
 
-func (p *DamlPackage) computeResolvedDependencies(defaultLocation *ArtifactLocation) (map[string]*ResolvedDependency, error) {
-	resolved := map[string]*ResolvedDependency{}
+func parseLocations(ds []string, artifactLocations ArtifactLocations, defaultLocation *ArtifactLocation) (map[string]*ParsedDarDependency, error) {
+	parsedLocations := map[string]*ParsedDarDependency{}
 
 	var errs []error
 
-	for _, d := range p.Dependencies {
+	for _, d := range ds {
 		if strings.HasPrefix(d, "oci://") {
 			u, err := url.Parse(d)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("couldn't parse dependency url %q: %w", d, err))
 				continue
 			}
-			resolved[d] = &ResolvedDependency{FullUrl: u}
+			parsedLocations[d] = &ParsedDarDependency{FullUrl: u}
 		} else if strings.HasPrefix(d, "http://") || strings.HasPrefix(d, "https://") {
 			// TODO
 			errs = append(errs, fmt.Errorf("couldn't parse dependency %q: http dependencies not yet supported", d))
@@ -105,7 +105,7 @@ func (p *DamlPackage) computeResolvedDependencies(defaultLocation *ArtifactLocat
 				errs = append(errs, fmt.Errorf("error parsing dependency %q: Dependencies beginning with @ must be of the form '@<artifact-location>/<suffix>'", d))
 				continue
 			}
-			location, ok := p.ArtifactLocations[parsed[1]]
+			location, ok := artifactLocations[parsed[1]]
 			if !ok {
 				errs = append(errs, fmt.Errorf("dependency %q has no corresponding artifact location", d))
 				continue
@@ -122,7 +122,7 @@ func (p *DamlPackage) computeResolvedDependencies(defaultLocation *ArtifactLocat
 				errs = append(errs, fmt.Errorf("couldn't parse full url %q for dependency %q: ", rawUrl, d))
 				continue
 			}
-			resolved[d] = &ResolvedDependency{
+			parsedLocations[d] = &ParsedDarDependency{
 				Location: location,
 				FullUrl:  u,
 			}
@@ -138,7 +138,7 @@ func (p *DamlPackage) computeResolvedDependencies(defaultLocation *ArtifactLocat
 				errs = append(errs, fmt.Errorf("couldn't parse full url %q for dependency %q: ", rawUrl, d))
 				continue
 			}
-			resolved[d] = &ResolvedDependency{
+			parsedLocations[d] = &ParsedDarDependency{
 				Location: defaultLocation,
 				FullUrl:  u,
 			}
@@ -151,7 +151,7 @@ func (p *DamlPackage) computeResolvedDependencies(defaultLocation *ArtifactLocat
 				errs = append(errs, fmt.Errorf("couldn't parse full url %q for dependency %q: ", s, d))
 				continue
 			}
-			resolved[d] = &ResolvedDependency{
+			parsedLocations[d] = &ParsedDarDependency{
 				Location: nil,
 				FullUrl:  u,
 			}
@@ -162,5 +162,5 @@ func (p *DamlPackage) computeResolvedDependencies(defaultLocation *ArtifactLocat
 		return nil, errors.Join(errs...)
 	}
 
-	return resolved, nil
+	return parsedLocations, nil
 }

--- a/pkg/darpuller/darpuller.go
+++ b/pkg/darpuller/darpuller.go
@@ -39,7 +39,7 @@ func New(config *assistantconfig.Config) *OciDarPuller {
 	}
 }
 
-func (a *OciDarPuller) PullDar(ctx context.Context, dar *damlpackage.ResolvedDependency) (*PulledDar, error) {
+func (a *OciDarPuller) PullDar(ctx context.Context, dar *damlpackage.ParsedDarDependency) (*PulledDar, error) {
 	result, err := a.doPullDar(ctx, dar)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (a *OciDarPuller) PullDar(ctx context.Context, dar *damlpackage.ResolvedDep
 	return result, nil
 }
 
-func (a *OciDarPuller) doPullDar(ctx context.Context, dar *damlpackage.ResolvedDependency) (*PulledDar, error) {
+func (a *OciDarPuller) doPullDar(ctx context.Context, dar *damlpackage.ParsedDarDependency) (*PulledDar, error) {
 	repo, ref, err := dar.GetOciRepo()
 	if err != nil {
 		return nil, err

--- a/pkg/darpuller/darpuller_test.go
+++ b/pkg/darpuller/darpuller_test.go
@@ -36,7 +36,7 @@ func TestOciDarPuller(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	dar := &damlpackage.ResolvedDependency{
+	dar := &damlpackage.ParsedDarDependency{
 		FullUrl: u,
 		Location: &damlpackage.ArtifactLocation{
 			Client: &auth.Client{Client: registry.Client()},

--- a/pkg/packagelock/lock.go
+++ b/pkg/packagelock/lock.go
@@ -45,7 +45,7 @@ type Dar struct {
 	Digest string   `yaml:"digest,omitempty"`
 	Path   string   `yaml:"path"`
 
-	Dependency *damlpackage.ResolvedDependency `yaml:"-"`
+	Dependency *damlpackage.ParsedDarDependency `yaml:"-"`
 }
 
 func ReadPackageLock(filePath string) (*PackageLock, error) {

--- a/pkg/packagelock/locker.go
+++ b/pkg/packagelock/locker.go
@@ -181,7 +181,7 @@ func (l *Locker) computeExpectedLockfile(packageDirAbsPath string) (*PackageLock
 	}
 
 	// TODO de-duplicate p.ResolvedDependencies first
-	expectedDars := lo.MapToSlice(p.ResolvedDependencies, func(_ string, d *damlpackage.ResolvedDependency) *Dar {
+	expectedDars := lo.MapToSlice(p.ParsedDarDependencies.Dependencies, func(_ string, d *damlpackage.ParsedDarDependency) *Dar {
 		return &Dar{
 			URI:        d.FullUrl,
 			Dependency: d,

--- a/pkg/resolution/resolution.go
+++ b/pkg/resolution/resolution.go
@@ -28,11 +28,13 @@ type Packages map[string]*Package
 type DefaultSDK map[string]*Package
 
 type Package struct {
-	Errors       []*resolutionerrors.ResolutionError `yaml:"errors,omitempty"`
-	Components   map[string]string                   `yaml:"components,omitempty"`
-	ComponentsV2 map[string]map[string]string        `yaml:"componentsV2,omitempty"`
-	Imports      Imports                             `yaml:"imports,omitempty"`
-	SdkVersion   string                              `yaml:"sdk-version"`
+	Errors                   []*resolutionerrors.ResolutionError `yaml:"errors,omitempty"`
+	Components               map[string]string                   `yaml:"components,omitempty"`
+	ComponentsV2             map[string]map[string]string        `yaml:"componentsV2,omitempty"`
+	Imports                  Imports                             `yaml:"imports,omitempty"`
+	SdkVersion               string                              `yaml:"sdk-version"`
+	ResolvedDependencies     []string                            `yaml:"resolved-dependencies"`
+	ResolvedDataDependencies []string                            `yaml:"resolved-data-dependencies"`
 }
 
 // Imports is export Var -> paths list mapping

--- a/pkg/resolver/deepresolver.go
+++ b/pkg/resolver/deepresolver.go
@@ -9,15 +9,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"daml.com/x/assistant/cmd/dpm/cmd/resolve/resolutionerrors"
 	"daml.com/x/assistant/pkg/assembler"
 	"daml.com/x/assistant/pkg/assembler/assemblyplan"
 	"daml.com/x/assistant/pkg/assistantconfig"
+	"daml.com/x/assistant/pkg/damlpackage"
+	"daml.com/x/assistant/pkg/darmanifest"
 	"daml.com/x/assistant/pkg/multipackage"
 	"daml.com/x/assistant/pkg/packagelock"
 	"daml.com/x/assistant/pkg/resolution"
 	"daml.com/x/assistant/pkg/schema"
+	"daml.com/x/assistant/pkg/utils"
 	"github.com/samber/lo"
 )
 
@@ -110,20 +114,18 @@ func (d *DeepResolver) resolvePackageAndDars(ctx context.Context, absPath string
 		return nil, err
 	}
 
-	if !assistantconfig.DpmLockfileEnabled() {
-		return result.ShallowResolution, nil
-	}
+	if assistantconfig.DpmLockfileEnabled() {
+		lock, err := packagelock.ReadPackageLock(filepath.Join(absPath, assistantconfig.DpmLockFileName))
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
 
-	lock, err := packagelock.ReadPackageLock(filepath.Join(absPath, assistantconfig.DpmLockFileName))
-	if errors.Is(err, os.ErrNotExist) {
-		return nil, err
-	}
-
-	paths := lo.Map(lock.Dars, func(d *packagelock.Dar, _ int) string {
-		return d.Path
-	})
-	if len(paths) > 0 {
-		result.ShallowResolution.Imports[resolution.DarImportsFields] = paths
+		paths := lo.Map(lock.Dars, func(d *packagelock.Dar, _ int) string {
+			return d.Path
+		})
+		if len(paths) > 0 {
+			result.ShallowResolution.Imports[resolution.DarImportsFields] = paths
+		}
 	}
 
 	return result.ShallowResolution, nil
@@ -138,7 +140,82 @@ func (d *DeepResolver) resolvePackage(ctx context.Context, absPath string) (*ass
 	if err != nil {
 		return nil, err
 	}
+
+	if assistantconfig.DpmDarsEnabled() {
+		resolvedDeps, resolvedDataDeps, err := d.resolvePackageDars(absPath)
+		if err != nil {
+			return nil, err
+		}
+		result.ShallowResolution.ResolvedDependencies = resolvedDeps
+		result.ShallowResolution.ResolvedDataDependencies = resolvedDataDeps
+	}
+
 	return result, nil
+}
+
+func (d *DeepResolver) resolvePackageDars(absPath string) (deps []string, dataDeps []string, err error) {
+	p, err := damlpackage.Read(filepath.Join(absPath, assistantconfig.DamlPackageFilename))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var errs []error
+
+	for _, dar := range p.ParsedDarDependencies.Dependencies {
+		r, err := d.resolveDar(dar)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		deps = append(deps, r)
+	}
+
+	for _, dar := range p.ParsedDarDependencies.DataDependencies {
+		r, err := d.resolveDar(dar)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		deps = append(deps, r)
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return nil, nil, err
+	}
+
+	return
+}
+
+func (d *DeepResolver) resolveDar(dar *damlpackage.ParsedDarDependency) (string, error) {
+	scheme := dar.FullUrl.Scheme
+
+	if scheme == "builtin" || scheme == "file" {
+		return strings.TrimPrefix(dar.FullUrl.String(), scheme+"://"), nil
+	}
+
+	if scheme == "oci" {
+		_, ref, err := dar.GetOciRepo()
+		if err != nil {
+			return "", err
+		}
+
+		darDir := d.config.CachePathForDar(ref.Registry, ref.Repository, ref.Reference)
+		ok, err := utils.DirExists(darDir)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", fmt.Errorf("dar %q is not installed", dar.FullUrl)
+		}
+
+		darManifest, err := darmanifest.ReadDarManifest(darDir)
+		if err != nil {
+			return "", err
+		}
+		return darManifest.Spec.Path, nil
+	}
+
+	return "", fmt.Errorf("unsupported schema %s", scheme)
 }
 
 func (d *DeepResolver) resolveDefaultSdk(ctx context.Context) resolution.DefaultSDK {

--- a/pkg/resolver/deepresolver.go
+++ b/pkg/resolver/deepresolver.go
@@ -98,7 +98,7 @@ func (d *DeepResolver) resolve(ctx context.Context, packageAbsolutePaths ...stri
 
 		if result, err := d.resolvePackageAndDars(ctx, resolvedPath); err != nil {
 			pkgs[resolvedPath] = &resolution.Package{
-				Errors: []*resolutionerrors.ResolutionError{resolutionerrors.Standardize(err)},
+				Errors: resolutionerrors.Standardize(err),
 			}
 		} else {
 			pkgs[resolvedPath] = result
@@ -205,7 +205,7 @@ func (d *DeepResolver) resolveDar(dar *damlpackage.ParsedDarDependency) (string,
 			return "", err
 		}
 		if !ok {
-			return "", fmt.Errorf("dar %q is not installed", dar.FullUrl)
+			return "", resolutionerrors.NewDarNotInstalled(fmt.Errorf("dar %q is not installed", dar.FullUrl))
 		}
 
 		darManifest, err := darmanifest.ReadDarManifest(darDir)
@@ -227,7 +227,7 @@ func (d *DeepResolver) resolveDefaultSdk(ctx context.Context) resolution.Default
 		// in case where we can't determine what the sdk-version is,
 		// because there aren't any installed, and the user didn't set DPM_SDK_VERSION
 		defaultSdk[assistantconfig.GetSdkVersionOverrideWithFallback("unknown–sdk-version")] = &resolution.Package{
-			Errors: []*resolutionerrors.ResolutionError{resolutionerrors.Standardize(err)},
+			Errors: resolutionerrors.Standardize(err),
 		}
 		return defaultSdk
 	}
@@ -235,7 +235,7 @@ func (d *DeepResolver) resolveDefaultSdk(ctx context.Context) resolution.Default
 	result, err := d.assembler.ReadAndAssemble(ctx, installedSdk.ManifestPath)
 	if err != nil {
 		defaultSdk[installedSdk.Version.String()] = &resolution.Package{
-			Errors: []*resolutionerrors.ResolutionError{resolutionerrors.Standardize(err)},
+			Errors: resolutionerrors.Standardize(err),
 		}
 	} else {
 		v := installedSdk.Version.String()

--- a/pkg/testutil/testdata/daml-dependencies/daml.yaml
+++ b/pkg/testutil/testdata/daml-dependencies/daml.yaml
@@ -2,12 +2,12 @@ dependencies:
   - daml-script
 #  - ./meep.dar TODO
   - foo:devnet
-  - oci://localhost:$TEST_DPM_REGISTRY_PORT/some/dars/foo:1.2.3
+  - oci://$TEST_DPM_REGISTRY/some/dars/foo:1.2.3
   - "@my-location/foo:4.5.6"
 
 artifact-locations:
   "@digital-asset":
      default: true
-     url: oci://localhost:$TEST_DPM_REGISTRY_PORT/more/official/dars
+     url: oci://$TEST_DPM_REGISTRY/more/official/dars
   "@my-location":
-      url: oci://localhost:$TEST_DPM_REGISTRY_PORT/some/dars/n/stuff
+      url: oci://$TEST_DPM_REGISTRY/some/dars/n/stuff

--- a/pkg/testutil/testdata/daml-dependencies/daml.yaml
+++ b/pkg/testutil/testdata/daml-dependencies/daml.yaml
@@ -1,13 +1,12 @@
 dependencies:
   - daml-script
-#  - ./meep.dar TODO
-  - foo:devnet
-  - oci://$TEST_DPM_REGISTRY/some/dars/foo:1.2.3
+  - foo:3.4.5
+  - oci://localhost:123/some/dars/foo:1.2.3
   - "@my-location/foo:4.5.6"
 
 artifact-locations:
   "@digital-asset":
-     default: true
-     url: oci://$TEST_DPM_REGISTRY/more/official/dars
+    default: true
+    url: oci://localhost:1456/more/official/dars
   "@my-location":
-      url: oci://$TEST_DPM_REGISTRY/some/dars/n/stuff
+    url: oci://localhost:1456/some/dars/n/stuff

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -178,7 +178,7 @@ func GetRemote(registry *httptest.Server) *assistantremote.Remote {
 	return assistantremote.NewWithCustomClient(strings.TrimPrefix(registry.URL, prefix), &auth.Client{Client: registry.Client()}, insecure)
 }
 
-func StartRegistry(t *testing.T) (client *assistantremote.Remote, reg *httptest.Server) {
+func StartDpmRegistry(t *testing.T) (client *assistantremote.Remote, reg *httptest.Server) {
 	reg = httptest.NewServer(registry.New())
 	t.Cleanup(func() { reg.Close() })
 	regUrl := strings.TrimPrefix(reg.URL, "http://")


### PR DESCRIPTION
- adds (and populates) `resolved-dependencies` and `resolved-data-dependencies` to the `dpm resolve` output`
- introcuded `DPM_DARS_ENABLED` feature flag