### PR TITLE
support filepath-based dar deps

### DIFF
--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -58,13 +58,13 @@ data-dependencies:
 	})
 
 	t.Run("resolution of absolute file-path dars", func(t *testing.T) {
-		absoluteDar, _ := filepath.Abs(testutil.TestdataPath(t, "test-dar", "test.dar"))
+		absoluteDarPath, _ := filepath.Abs(testutil.TestdataPath(t, "test-dar", "test.dar"))
 		ActivateDamlYamlForTest(t, fmt.Sprintf(`
 dependencies:
   - %s
 data-dependencies:
   - %s
-`, absoluteDar, absoluteDar))
+`, absoluteDarPath, absoluteDarPath))
 		res := lo.Values(runResolveCommand(t).Packages)[0]
 
 		assert.Contains(t, res.ResolvedDependencies[0], "test.dar")

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -10,57 +10,68 @@ import (
 	"testing"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
-	"daml.com/x/assistant/pkg/resolution"
 	"daml.com/x/assistant/pkg/testutil"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func (suite *MainSuite) TestResolutionOfDarDependencies() {
+func (suite *MainSuite) TestResolutionOfBuiltInDarDependencies() {
 	t := suite.T()
-
-	// enable feature flag
 	t.Setenv(assistantconfig.DpmDarsEnabledEnvVar, "true")
 
-	// setup
-	tmpDpmHome, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDpmHome)
+	ActivateDamlYamlForTest(t, `
+dependencies:
+  - daml-script
+data-dependencies:
+  - foo-script
+`)
 
-	t.Run("dpm resolve data-dependencies and dependencies fields", func(t *testing.T) {
-		var res *resolution.Package
-		testDar, _ := filepath.Abs(testutil.TestdataPath(t, "test-dar", "test.dar"))
+	res := lo.Values(runResolveCommand(t).Packages)[0]
+	assert.Contains(t, res.ResolvedDependencies, "daml-script")
+	assert.Contains(t, res.ResolvedDataDependencies, "foo-script")
+}
 
+func (suite *MainSuite) TestResolutionOfFilePathBasedDarDependencies() {
+	t := suite.T()
+	t.Setenv(assistantconfig.DpmDarsEnabledEnvVar, "true")
+
+	t.Run("resolution of relative file-path dars", func(t *testing.T) {
 		packageDir := ActivateDamlYamlForTest(t, fmt.Sprintf(`
 dependencies:
-  - %s  # absolute filepath dar
-  - daml-script
-
+  - ./relative.dar
 data-dependencies:
-  - ./test2.dar
-  - foo-script
-`, testDar))
+  - ./relative.dar
+`))
+		os.WriteFile(
+			filepath.Join(packageDir, "relative.dar"),
+			[]byte("another fake test dar"),
+			06444)
 
-		test2Dar := filepath.Join(packageDir, "test2.dar")
-		os.WriteFile(test2Dar, []byte("another fake test dar"), 06444)
+		res := lo.Values(runResolveCommand(t).Packages)[0]
 
-		t.Run("dpm resolve command exits successfully", func(t *testing.T) {
-			output := runResolveCommand(t)
-			res = lo.Values(output.Packages)[0]
-		})
+		assert.Contains(t, res.ResolvedDependencies[0], "relative.dar")
+		checkDar(t, res.ResolvedDependencies[0])
 
-		t.Run("builtin dars get included in resolution", func(t *testing.T) {
-			assert.Contains(t, res.ResolvedDependencies, "daml-script")
-			assert.Contains(t, res.ResolvedDataDependencies, "foo-script")
-		})
+		assert.Contains(t, res.ResolvedDataDependencies[0], "relative.dar")
+		checkDar(t, res.ResolvedDataDependencies[0])
+	})
 
-		t.Run("relative filepath-based dars get included in resolution", func(t *testing.T) {
-			assert.Contains(t, res.ResolvedDependencies, testDar)
-		})
-		t.Run("absolute filepath-based dars get included in resolution", func(t *testing.T) {
-			assert.Contains(t, res.ResolvedDataDependencies, test2Dar)
-		})
+	t.Run("resolution of absolute file-path dars", func(t *testing.T) {
+		absoluteDar, _ := filepath.Abs(testutil.TestdataPath(t, "test-dar", "test.dar"))
+		ActivateDamlYamlForTest(t, fmt.Sprintf(`
+dependencies:
+  - %s
+data-dependencies:
+  - %s
+`, absoluteDar, absoluteDar))
+		res := lo.Values(runResolveCommand(t).Packages)[0]
+
+		assert.Contains(t, res.ResolvedDependencies[0], "test.dar")
+		checkDar(t, res.ResolvedDependencies[0])
+
+		assert.Contains(t, res.ResolvedDataDependencies[0], "test.dar")
+		checkDar(t, res.ResolvedDataDependencies[0])
 	})
 }
 
@@ -68,7 +79,11 @@ func ActivateDamlYamlForTest(t *testing.T, s string) (packageDir string) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "daml.yaml"), []byte(s), 0666))
-	d, err := filepath.EvalSymlinks(tmpDir)
+	return tmpDir
+}
+
+func checkDar(t *testing.T, darFile string) {
+	assert.True(t, filepath.IsAbs(darFile), "expecting absolute dar paths in the output")
+	_, err := os.ReadFile(darFile)
 	require.NoError(t, err)
-	return d
 }

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -29,37 +29,46 @@ func (suite *MainSuite) TestResolutionOfDarDependencies() {
 	t.Setenv(assistantconfig.DpmHomeEnvVar, tmpDpmHome)
 
 	t.Run("dpm resolve data-dependencies and dependencies fields", func(t *testing.T) {
-		var res *resolution.Resolution
+		var res *resolution.Package
+		testDar, _ := filepath.Abs(testutil.TestdataPath(t, "test-dar", "test.dar"))
 
-		localDar := testutil.TestdataPath(t, "test-dar", "test.dar")
-		ActivateDamlYamlForTest(t, fmt.Sprintf(`
+		packageDir := ActivateDamlYamlForTest(t, fmt.Sprintf(`
 dependencies:
+  - %s  # absolute filepath dar
   - daml-script
-  - %s  # filepath-based dar
 
 data-dependencies:
+  - ./test2.dar
   - foo-script
-  - %s  # filepath-based dar
-`, localDar, localDar))
+`, testDar))
+
+		test2Dar := filepath.Join(packageDir, "test2.dar")
+		os.WriteFile(test2Dar, []byte("another fake test dar"), 06444)
 
 		t.Run("dpm resolve command exits successfully", func(t *testing.T) {
-			res = runResolveCommand(t)
+			output := runResolveCommand(t)
+			res = lo.Values(output.Packages)[0]
 		})
 
 		t.Run("builtin dars get included in resolution", func(t *testing.T) {
-			assert.Contains(t, lo.Values(res.Packages)[0].ResolvedDependencies, "daml-script")
-			assert.Contains(t, lo.Values(res.Packages)[0].ResolvedDataDependencies, "foo-script")
+			assert.Contains(t, res.ResolvedDependencies, "daml-script")
+			assert.Contains(t, res.ResolvedDataDependencies, "foo-script")
 		})
 
-		t.Run("filepath-based dars get included in resolution", func(t *testing.T) {
-			assert.Contains(t, lo.Values(res.Packages)[0].ResolvedDependencies, localDar)
-			assert.Contains(t, lo.Values(res.Packages)[0].ResolvedDataDependencies, localDar)
+		t.Run("relative filepath-based dars get included in resolution", func(t *testing.T) {
+			assert.Contains(t, res.ResolvedDependencies, testDar)
+		})
+		t.Run("absolute filepath-based dars get included in resolution", func(t *testing.T) {
+			assert.Contains(t, res.ResolvedDataDependencies, test2Dar)
 		})
 	})
 }
 
-func ActivateDamlYamlForTest(t *testing.T, s string) {
+func ActivateDamlYamlForTest(t *testing.T, s string) (packageDir string) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "daml.yaml"), []byte(s), 0666))
+	d, err := filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, err)
+	return d
 }

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -4,12 +4,14 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/resolution"
+	"daml.com/x/assistant/pkg/testutil"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,12 +31,16 @@ func (suite *MainSuite) TestResolutionOfDarDependencies() {
 	t.Run("dpm resolve data-dependencies and dependencies fields", func(t *testing.T) {
 		var res *resolution.Resolution
 
-		ActivateDamlYamlForTest(t, `
+		localDar := testutil.TestdataPath(t, "test-dar", "test.dar")
+		ActivateDamlYamlForTest(t, fmt.Sprintf(`
 dependencies:
   - daml-script
+  - %s  # filepath-based dar
+
 data-dependencies:
   - foo-script
-`)
+  - %s  # filepath-based dar
+`, localDar, localDar))
 
 		t.Run("dpm resolve command exits successfully", func(t *testing.T) {
 			res = runResolveCommand(t)
@@ -43,6 +49,11 @@ data-dependencies:
 		t.Run("builtin dars get included in resolution", func(t *testing.T) {
 			assert.Contains(t, lo.Values(res.Packages)[0].ResolvedDependencies, "daml-script")
 			assert.Contains(t, lo.Values(res.Packages)[0].ResolvedDataDependencies, "foo-script")
+		})
+
+		t.Run("filepath-based dars get included in resolution", func(t *testing.T) {
+			assert.Contains(t, lo.Values(res.Packages)[0].ResolvedDependencies, localDar)
+			assert.Contains(t, lo.Values(res.Packages)[0].ResolvedDataDependencies, localDar)
 		})
 	})
 }

--- a/pkg/damlpackage/damlproject.go
+++ b/pkg/damlpackage/damlproject.go
@@ -32,17 +32,20 @@ type DamlPackage struct {
 	DataDependencies      []string               `yaml:"data-dependencies,omitempty"`
 	ArtifactLocations     ArtifactLocations      `yaml:"artifact-locations,omitempty"`
 	ParsedDarDependencies *ParsedDarDependencies `yaml:"-"`
+
+	// absolute path to daml.yaml
+	AbsolutePath string `yaml:"-"`
 }
 
-func Read(filePath string) (*DamlPackage, error) {
-	bytes, err := os.ReadFile(filePath)
+func Read(absoluteFilePath string) (*DamlPackage, error) {
+	bytes, err := os.ReadFile(absoluteFilePath)
 	if err != nil {
 		return nil, err
 	}
-	return ReadFromContents(bytes)
+	return ReadFromContents(bytes, absoluteFilePath)
 }
 
-func ReadFromContents(contents []byte) (*DamlPackage, error) {
+func ReadFromContents(contents []byte, absoluteFilePath string) (*DamlPackage, error) {
 	expanded, err := expandEnv(contents)
 	if err != nil {
 		return nil, err
@@ -52,6 +55,8 @@ func ReadFromContents(contents []byte) (*DamlPackage, error) {
 	if err := yaml.UnmarshalWithOptions(expanded, &obj); err != nil {
 		return nil, err
 	}
+
+	obj.AbsolutePath = absoluteFilePath
 
 	if obj.ComponentsList != nil {
 		obj.Components, err = obj.ComponentsList.ToMap()
@@ -84,13 +89,13 @@ func ReadFromContents(contents []byte) (*DamlPackage, error) {
 
 		obj.ParsedDarDependencies = &ParsedDarDependencies{}
 		if len(obj.Dependencies) > 0 {
-			obj.ParsedDarDependencies.Dependencies, err = parseLocations(obj.Dependencies, obj.ArtifactLocations, defaultLocation)
+			obj.ParsedDarDependencies.Dependencies, err = obj.parseLocations(obj.Dependencies, obj.ArtifactLocations, defaultLocation)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse provided dependencies: %w", err)
 			}
 		}
 		if len(obj.DataDependencies) > 0 {
-			obj.ParsedDarDependencies.DataDependencies, err = parseLocations(obj.DataDependencies, obj.ArtifactLocations, defaultLocation)
+			obj.ParsedDarDependencies.DataDependencies, err = obj.parseLocations(obj.DataDependencies, obj.ArtifactLocations, defaultLocation)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse provided data-dependencies: %w", err)
 			}

--- a/pkg/damlpackage/damlproject_test.go
+++ b/pkg/damlpackage/damlproject_test.go
@@ -50,18 +50,18 @@ override-components:
 `
 
 	t.Run("cannot use both fields together", func(t *testing.T) {
-		_, err := ReadFromContents(makeDamlYaml(componentsField, overrideComponentsField))
+		_, err := ReadFromContents(makeDamlYaml(componentsField, overrideComponentsField), "-")
 		require.Error(t, err)
 	})
 
 	t.Run("populates components fields", func(t *testing.T) {
-		p, err := ReadFromContents(makeDamlYaml(componentsField))
+		p, err := ReadFromContents(makeDamlYaml(componentsField), "-")
 		require.NoError(t, err)
 		assert.Contains(t, p.Components, "foo")
 	})
 
 	t.Run("populates components fields from override-components", func(t *testing.T) {
-		p, err := ReadFromContents(makeDamlYaml(overrideComponentsField))
+		p, err := ReadFromContents(makeDamlYaml(overrideComponentsField), "-")
 		require.NoError(t, err)
 		assert.Contains(t, p.Components, "damlc")
 	})

--- a/pkg/damlpackage/damlproject_test.go
+++ b/pkg/damlpackage/damlproject_test.go
@@ -50,18 +50,18 @@ override-components:
 `
 
 	t.Run("cannot use both fields together", func(t *testing.T) {
-		_, err := ReadFromContents(makeDamlYaml(componentsField, overrideComponentsField), "-")
+		_, err := ReadFromContents(makeDamlYaml(componentsField, overrideComponentsField), "")
 		require.Error(t, err)
 	})
 
 	t.Run("populates components fields", func(t *testing.T) {
-		p, err := ReadFromContents(makeDamlYaml(componentsField), "-")
+		p, err := ReadFromContents(makeDamlYaml(componentsField), "")
 		require.NoError(t, err)
 		assert.Contains(t, p.Components, "foo")
 	})
 
 	t.Run("populates components fields from override-components", func(t *testing.T) {
-		p, err := ReadFromContents(makeDamlYaml(overrideComponentsField), "-")
+		p, err := ReadFromContents(makeDamlYaml(overrideComponentsField), "")
 		require.NoError(t, err)
 		assert.Contains(t, p.Components, "damlc")
 	})

--- a/pkg/damlpackage/locations.go
+++ b/pkg/damlpackage/locations.go
@@ -95,10 +95,16 @@ func parseLocations(ds []string, artifactLocations ArtifactLocations, defaultLoc
 			// TODO
 			errs = append(errs, fmt.Errorf("couldn't parse dependency %q: http dependencies not yet supported", d))
 			continue
-		} else if strings.HasPrefix(d, ".") {
-			// TODO
-			errs = append(errs, fmt.Errorf("couldn't parse dependency %q: file paths not yet supported", d))
-			continue
+		} else if isFilePath(d) {
+			u, err := url.Parse("builtin://" + d)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			parsedLocations[d] = &ParsedDarDependency{
+				Location: nil,
+				FullUrl:  u,
+			}
 		} else if strings.HasPrefix(d, "@") {
 			parsed := regex.FindStringSubmatch(d)
 			if len(parsed) < 2 {
@@ -163,4 +169,10 @@ func parseLocations(ds []string, artifactLocations ArtifactLocations, defaultLoc
 	}
 
 	return parsedLocations, nil
+}
+
+func isFilePath(s string) bool {
+	return strings.HasPrefix(s, ".") ||
+		strings.HasPrefix(s, "/") ||
+		strings.Index(s, ":") == 1
 }

--- a/pkg/damlpackage/locations.go
+++ b/pkg/damlpackage/locations.go
@@ -99,7 +99,7 @@ func (p *DamlPackage) parseLocations(ds []string, artifactLocations ArtifactLoca
 			continue
 		} else if isFilePath(d) {
 			absPath := utils.ResolvePath(filepath.Dir(p.AbsolutePath), d)
-			u, err := url.Parse("file://" + absPath)
+			u, err := url.Parse("file://" + filepath.ToSlash(absPath))
 			if err != nil {
 				errs = append(errs, err)
 				continue

--- a/pkg/damlpackage/locations.go
+++ b/pkg/damlpackage/locations.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"strings"
 
 	"daml.com/x/assistant/pkg/assistantconfig/assistantremote"
+	"daml.com/x/assistant/pkg/utils"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -78,7 +80,7 @@ func (ls ArtifactLocations) GetDefaultLocation() (name string, location *Artifac
 	return
 }
 
-func parseLocations(ds []string, artifactLocations ArtifactLocations, defaultLocation *ArtifactLocation) (map[string]*ParsedDarDependency, error) {
+func (p *DamlPackage) parseLocations(ds []string, artifactLocations ArtifactLocations, defaultLocation *ArtifactLocation) (map[string]*ParsedDarDependency, error) {
 	parsedLocations := map[string]*ParsedDarDependency{}
 
 	var errs []error
@@ -96,7 +98,8 @@ func parseLocations(ds []string, artifactLocations ArtifactLocations, defaultLoc
 			errs = append(errs, fmt.Errorf("couldn't parse dependency %q: http dependencies not yet supported", d))
 			continue
 		} else if isFilePath(d) {
-			u, err := url.Parse("builtin://" + d)
+			absPath := utils.ResolvePath(filepath.Dir(p.AbsolutePath), d)
+			u, err := url.Parse("file://" + absPath)
 			if err != nil {
 				errs = append(errs, err)
 				continue

--- a/pkg/resolver/deepresolver.go
+++ b/pkg/resolver/deepresolver.go
@@ -127,7 +127,7 @@ func (d *DeepResolver) resolvePackageAndDars(ctx context.Context, absPath string
 	if len(paths) > 0 {
 		result.ShallowResolution.Imports[resolution.DarImportsFields] = paths
 	}
-	
+
 	return result.ShallowResolution, nil
 }
 
@@ -192,7 +192,21 @@ func (d *DeepResolver) resolveDar(dar *damlpackage.ParsedDarDependency) (string,
 	if scheme == "builtin" || scheme == "file" {
 		return strings.TrimPrefix(dar.FullUrl.String(), scheme+"://"), nil
 	}
+	if scheme == "file" {
+		f := strings.TrimPrefix(dar.FullUrl.String(), scheme+"://")
+		// verify the file exists
+		if _, err := os.Stat(f); err != nil {
+			return "", fmt.Errorf("dar file doesn't exist: %w", err)
+		}
 
+		// evaluate symlink (if it is one)
+		evaluatedSymlink, err := filepath.EvalSymlinks(f)
+		if err != nil {
+			return "", err
+		}
+		
+		return evaluatedSymlink, nil
+	}
 	if scheme == "oci" {
 		// TODO
 		return "", fmt.Errorf("oci dars not yet fully implemented")


### PR DESCRIPTION
`dpm resolve` support for 

```
dependencies:
  - ./foo.dar
  - /whatever/foo.dar
  - C:\\blah.dar
```
and 
```
data-dependencies:
  - ./foo.dar
  - /whatever/foo.dar
```