### PR TITLE
resolve dars sourced from oci

### DIFF
--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -10,9 +10,7 @@ import (
 	"testing"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
-	"daml.com/x/assistant/pkg/assistantconfig/assistantremote"
-	ociconsts "daml.com/x/assistant/pkg/oci"
-	"daml.com/x/assistant/pkg/ocipusher/darpusher"
+	"daml.com/x/assistant/pkg/resolution"
 	"daml.com/x/assistant/pkg/testutil"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -34,6 +32,48 @@ data-dependencies:
 	res := lo.Values(runResolveCommand(t).Packages)[0]
 	assert.Contains(t, res.ResolvedDependencies, "daml-script")
 	assert.Contains(t, res.ResolvedDataDependencies, "foo-script")
+}
+
+func (suite *MainSuite) TestResolutionOfOciDarDependencies() {
+	var res *resolution.Package
+
+	t := suite.T()
+	t.Setenv(assistantconfig.DpmDarsEnabledEnvVar, "true")
+
+	config := testutil.MkConfig(t)
+	t.Chdir(testutil.TestdataPath(t, "oci-dar-deps")) // fixture daml.yaml
+
+	// push dars to test registry
+	testutil.StartRegistry(t)
+
+	reg := os.Getenv(assistantconfig.OciRegistryEnvVar)
+	fooDarRef, err := registry.ParseReference(fmt.Sprintf("%s/more/official/dars/foo:1.2.3", reg))
+	require.NoError(t, err)
+	barDarRef, err := registry.ParseReference(fmt.Sprintf("%s/some/dars/n/stuff/bar:4.5.6", reg))
+	require.NoError(t, err)
+
+	pushDar(t, "oci://"+fooDarRef.String())
+	pushDar(t, "oci://"+barDarRef.String())
+
+	t.Run("dpm install package", func(t *testing.T) {
+		require.NoError(t, createStdTestRootCmd(t, "install", "package").Execute())
+	})
+
+	t.Run("should execute dpm resolve without errors", func(t *testing.T) {
+		output := runResolveCommand(t)
+		res = lo.Values(output.Packages)[0]
+	})
+
+	t.Run("resolution output should contain dars sourced via OCI", func(t *testing.T) {
+		assert.Contains(t,
+			res.ResolvedDependencies,
+			filepath.Join(config.CachePathForDar(&fooDarRef), "test.dar"),
+		)
+		assert.Contains(t,
+			res.ResolvedDataDependencies,
+			filepath.Join(config.CachePathForDar(&barDarRef), "test.dar"),
+		)
+	})
 }
 
 func (suite *MainSuite) TestResolutionOfFilePathBasedDarDependencies() {
@@ -107,8 +147,8 @@ func (suite *MainSuite) TestDarInstallWithArtifactLocationAlias() {
 	barDarRef, err := registry.ParseReference(fmt.Sprintf("%s/some/dars/n/stuff/bar:4.5.6", reg))
 	require.NoError(t, err)
 
-	pushDar(t, fooDarRef)
-	pushDar(t, barDarRef)
+	pushDar(t, "oci://"+fooDarRef.String())
+	pushDar(t, "oci://"+barDarRef.String())
 
 	// install dars
 	ActivateDamlYamlForTest(t, `
@@ -135,24 +175,20 @@ artifact-locations:
 	})
 }
 
-func pushDar(t *testing.T, ref registry.Reference, extraTags ...string) {
-	pushOp, err := darpusher.DarNew(t.Context(), darpusher.DarOpts{
-		Artifact: &ociconsts.DarArtifact{
-			DarRepo: ref.Repository,
-		},
-		RawTag:              ref.Reference,
-		Dir:                 testutil.TestdataPath(t, "test-dar"),
-		RequiredAnnotations: ociconsts.DescriptorAnnotations{},
-	})
+func pushDar(t *testing.T, uri string, extraTags ...string) {
+	args := []string{
+		"publish", "dar", uri,
+		"-f", testutil.TestdataPath(t, "test-dar"),
+	}
 
-	require.NoError(t, err)
-	client, err := assistantremote.New(ref.Registry, "", true)
-	require.NoError(t, err)
+	if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
+		args = append(args, "--insecure")
+	}
 
-	_, err = pushOp.DarDo(t.Context(), client)
-	require.NoError(t, err)
-}
+	for _, tag := range extraTags {
+		args = append(args, "--extra-tags", tag)
+	}
 
-func mkConfig(t *testing.T) {
-
+	cmd := createStdTestRootCmd(t, args...)
+	require.NoError(t, cmd.Execute())
 }

--- a/cmd/dpm/cmd/resolve/resolutionerrors/resolutionerrors.go
+++ b/cmd/dpm/cmd/resolve/resolutionerrors/resolutionerrors.go
@@ -11,6 +11,7 @@ const (
 	DamlYamlNotFound  = "DAML_YAML_NOT_FOUND"
 	UnknownError      = "UNKNOWN_ERROR"
 	OutdatedLockfile  = "OUTDATED_DPM_LOCK"
+	DarNotInstalled   = "DAR_NOT_INSTALLED"
 )
 
 type ResolutionError struct {
@@ -88,6 +89,13 @@ func NewOutdatedLockfileError(cause error) *ResolutionError {
 func NewUnknownError(cause error) *ResolutionError {
 	return &ResolutionError{
 		Code:  UnknownError,
+		Cause: cause,
+	}
+}
+
+func NewDarNotInstalled(cause error) *ResolutionError {
+	return &ResolutionError{
+		Code:  DarNotInstalled,
 		Cause: cause,
 	}
 }

--- a/pkg/resolver/deepresolver.go
+++ b/pkg/resolver/deepresolver.go
@@ -16,10 +16,12 @@ import (
 	"daml.com/x/assistant/pkg/assembler/assemblyplan"
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/damlpackage"
+	"daml.com/x/assistant/pkg/darmanifest"
 	"daml.com/x/assistant/pkg/multipackage"
 	"daml.com/x/assistant/pkg/packagelock"
 	"daml.com/x/assistant/pkg/resolution"
 	"daml.com/x/assistant/pkg/schema"
+	"daml.com/x/assistant/pkg/utils"
 	"github.com/samber/lo"
 )
 
@@ -167,7 +169,7 @@ func (d *DeepResolver) resolvePackageDars(absPath string) (deps []string, dataDe
 			errs = append(errs, err)
 			continue
 		}
-		deps = append(deps, r)
+		deps = append(deps, r...)
 	}
 
 	for _, dar := range p.ParsedDarDependencies.DataDependencies {
@@ -176,7 +178,7 @@ func (d *DeepResolver) resolvePackageDars(absPath string) (deps []string, dataDe
 			errs = append(errs, err)
 			continue
 		}
-		dataDeps = append(dataDeps, r)
+		dataDeps = append(dataDeps, r...)
 	}
 
 	if err := errors.Join(errs...); err != nil {
@@ -186,33 +188,56 @@ func (d *DeepResolver) resolvePackageDars(absPath string) (deps []string, dataDe
 	return
 }
 
-func (d *DeepResolver) resolveDar(dar *damlpackage.ParsedDarDependency) (string, error) {
+func (d *DeepResolver) resolveDar(dar *damlpackage.ParsedDarDependency) ([]string, error) {
 	scheme := dar.FullUrl.Scheme
 
 	if scheme == "builtin" || scheme == "file" {
-		return strings.TrimPrefix(dar.FullUrl.String(), scheme+"://"), nil
+		return []string{strings.TrimPrefix(dar.FullUrl.String(), scheme+"://")}, nil
 	}
 	if scheme == "file" {
 		f := strings.TrimPrefix(dar.FullUrl.String(), scheme+"://")
 		// verify the file exists
 		if _, err := os.Stat(f); err != nil {
-			return "", fmt.Errorf("dar file doesn't exist: %w", err)
+			return nil, fmt.Errorf("dar file doesn't exist: %w", err)
 		}
 
 		// evaluate symlink (if it is one)
 		evaluatedSymlink, err := filepath.EvalSymlinks(f)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		
-		return evaluatedSymlink, nil
+
+		return []string{evaluatedSymlink}, nil
 	}
 	if scheme == "oci" {
-		// TODO
-		return "", fmt.Errorf("oci dars not yet fully implemented")
+		_, ref, err := dar.GetOciRemote()
+		if err != nil {
+			return nil, err
+		}
+
+		darDir := d.config.CachePathForDar(ref)
+		ok, err := utils.DirExists(darDir)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, resolutionerrors.NewDarNotInstalled(fmt.Errorf("dar %q is not installed", dar.FullUrl))
+		}
+
+		darManifestPath := filepath.Join(darDir, assistantconfig.DarManifestName)
+		darManifest, err := darmanifest.ReadDarManifest(darManifestPath)
+		if err != nil {
+			return nil, err
+		}
+
+		var dars []string
+		for _, p := range darManifest.Spec.Paths {
+			dars = append(dars, utils.ResolvePath(darDir, p))
+		}
+		return dars, nil
 	}
 
-	return "", fmt.Errorf("unsupported schema %s", scheme)
+	return nil, fmt.Errorf("unsupported schema %s", scheme)
 }
 
 func (d *DeepResolver) resolveDefaultSdk(ctx context.Context) resolution.DefaultSDK {

--- a/pkg/testutil/testdata/oci-dar-deps/daml.yaml
+++ b/pkg/testutil/testdata/oci-dar-deps/daml.yaml
@@ -1,0 +1,12 @@
+dependencies:
+  - "@digital-asset/foo:1.2.3"
+data-dependencies:
+  - "@my-location/bar:4.5.6"
+
+artifact-locations:
+  "@digital-asset":
+    url: oci://$DPM_REGISTRY/more/official/dars
+    insecure: true
+  "@my-location":
+    url: oci://$DPM_REGISTRY/some/dars/n/stuff
+    insecure: true


### PR DESCRIPTION
finish up handling of oci dar deps during `dpm resolve`. 
Oci dars should work end-to-end with this change 