### PR TITLE
move resolved dependencies under imports field in resolution

### DIFF
--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -30,8 +30,8 @@ data-dependencies:
 `)
 
 	res := lo.Values(runResolveCommand(t).Packages)[0]
-	assert.Contains(t, res.ResolvedDependencies, "daml-script")
-	assert.Contains(t, res.ResolvedDataDependencies, "foo-script")
+	assert.Contains(t, res.GetResolvedDependencies(), "daml-script")
+	assert.Contains(t, res.GetResolvedDataDependencies(), "foo-script")
 }
 
 func (suite *MainSuite) TestResolutionOfOciDarDependencies() {
@@ -66,11 +66,11 @@ func (suite *MainSuite) TestResolutionOfOciDarDependencies() {
 
 	t.Run("resolution output should contain dars sourced via OCI", func(t *testing.T) {
 		assert.Contains(t,
-			res.ResolvedDependencies,
+			res.GetResolvedDependencies(),
 			filepath.Join(config.CachePathForDar(&fooDarRef), "test.dar"),
 		)
 		assert.Contains(t,
-			res.ResolvedDataDependencies,
+			res.GetResolvedDataDependencies(),
 			filepath.Join(config.CachePathForDar(&barDarRef), "test.dar"),
 		)
 	})
@@ -94,11 +94,11 @@ data-dependencies:
 
 		res := lo.Values(runResolveCommand(t).Packages)[0]
 
-		assert.Contains(t, res.ResolvedDependencies[0], "relative.dar")
-		checkDar(t, res.ResolvedDependencies[0])
+		assert.Contains(t, res.GetResolvedDependencies()[0], "relative.dar")
+		checkDar(t, res.GetResolvedDependencies()[0])
 
-		assert.Contains(t, res.ResolvedDataDependencies[0], "relative.dar")
-		checkDar(t, res.ResolvedDataDependencies[0])
+		assert.Contains(t, res.GetResolvedDataDependencies()[0], "relative.dar")
+		checkDar(t, res.GetResolvedDataDependencies()[0])
 	})
 
 	t.Run("resolution of absolute file-path dars", func(t *testing.T) {
@@ -111,11 +111,11 @@ data-dependencies:
 `, absoluteDarPath, absoluteDarPath))
 		res := lo.Values(runResolveCommand(t).Packages)[0]
 
-		assert.Contains(t, res.ResolvedDependencies[0], "test.dar")
-		checkDar(t, res.ResolvedDependencies[0])
+		assert.Contains(t, res.GetResolvedDependencies()[0], "test.dar")
+		checkDar(t, res.GetResolvedDependencies()[0])
 
-		assert.Contains(t, res.ResolvedDataDependencies[0], "test.dar")
-		checkDar(t, res.ResolvedDataDependencies[0])
+		assert.Contains(t, res.GetResolvedDataDependencies()[0], "test.dar")
+		checkDar(t, res.GetResolvedDataDependencies()[0])
 	})
 
 	t.Run("resolution of symlink file-path dars", func(t *testing.T) {
@@ -130,7 +130,7 @@ dependencies:
 
 		res := lo.Values(runResolveCommand(t).Packages)[0]
 
-		assert.Contains(t, res.ResolvedDependencies[0], "test.dar")
+		assert.Contains(t, res.GetResolvedDependencies()[0], "test.dar")
 	})
 }
 

--- a/pkg/resolution/resolution.go
+++ b/pkg/resolution/resolution.go
@@ -28,14 +28,33 @@ type Packages map[string]*Package
 type DefaultSDK map[string]*Package
 
 type Package struct {
-	Errors                   []*resolutionerrors.ResolutionError `yaml:"errors,omitempty"`
-	Components               map[string]string                   `yaml:"components,omitempty"`
-	ComponentsV2             map[string]map[string]string        `yaml:"componentsV2,omitempty"`
-	Imports                  Imports                             `yaml:"imports,omitempty"`
-	SdkVersion               string                              `yaml:"sdk-version"`
-	ResolvedDependencies     []string                            `yaml:"resolved-dependencies"`
-	ResolvedDataDependencies []string                            `yaml:"resolved-data-dependencies"`
+	Errors       []*resolutionerrors.ResolutionError `yaml:"errors,omitempty"`
+	Components   map[string]string                   `yaml:"components,omitempty"`
+	ComponentsV2 map[string]map[string]string        `yaml:"componentsV2,omitempty"`
+	Imports      Imports                             `yaml:"imports,omitempty"`
+	SdkVersion   string                              `yaml:"sdk-version"`
 }
 
 // Imports is export Var -> paths list mapping
 type Imports map[string][]string
+
+const (
+	ResolvedDependenciesField     = "resolved-dependencies"
+	ResolvedDataDependenciesField = "resolved-data-dependencies"
+)
+
+func (pkg *Package) GetResolvedDependencies() []string {
+	result, ok := pkg.Imports[ResolvedDependenciesField]
+	if !ok {
+		return []string{}
+	}
+	return result
+}
+
+func (pkg *Package) GetResolvedDataDependencies() []string {
+	result, ok := pkg.Imports[ResolvedDataDependenciesField]
+	if !ok {
+		return []string{}
+	}
+	return result
+}

--- a/pkg/resolver/deepresolver.go
+++ b/pkg/resolver/deepresolver.go
@@ -148,8 +148,9 @@ func (d *DeepResolver) resolvePackage(ctx context.Context, absPath string) (*ass
 		if err != nil {
 			return nil, err
 		}
-		result.ShallowResolution.ResolvedDependencies = resolvedDeps
-		result.ShallowResolution.ResolvedDataDependencies = resolvedDataDeps
+
+		result.ShallowResolution.Imports[resolution.ResolvedDependenciesField] = resolvedDeps
+		result.ShallowResolution.Imports[resolution.ResolvedDataDependenciesField] = resolvedDataDeps
 	}
 
 	return result, nil


### PR DESCRIPTION
tested end-to-end, including a real `dpm build` with latest damlc that also support remote dars
```
~/dpm/dpm build
Running multi-package build of meep-main-another.

2026-06-04 15:52:35.16 [INFO]  [multi-package build]
Building /Users/sammyabed/da-dars/main

2026-06-04 15:52:37.53 [INFO]  [build]
Compiling meep-main-another to a DAR.
File:     daml
Hidden:   no
Range:    1:1-2:1
Source:   Daml-LF typechecker
Severity: DsWarning
Message:
warning while type checking package:
  The following dependencies are not used:
   - 85df5dc92103ff9dc0635fc1662606a6e316e81fd5740ce348cadbfd1c42845e (meep-main, 0.0.1)
  These dependencies can be removed from your daml.yaml
  Upgrade this warning to an error -Werror=unused-dependency
  Disable this warning entirely with -Wno-unused-dependency

2026-06-04 15:52:39.03 [INFO]  [build]
Created .daml/dist/meep-main-another-0.0.1.dar
```