### PR TITLE
dar deps: damlc intergration fixes

### DIFF
--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -114,21 +114,6 @@ data-dependencies:
 		assert.Contains(t, res.GetResolvedDataDependencies()[0], "test.dar")
 		checkDar(t, res.GetResolvedDataDependencies()[0])
 	})
-
-	t.Run("resolution of symlink file-path dars", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		darSymlink := filepath.Join(tmpDir, "symlink.dar")
-		require.NoError(t, os.Symlink(testutil.TestdataPath(t, "test-dar", "test.dar"), darSymlink))
-
-		ActivateDamlYamlForTest(t, fmt.Sprintf(`
-dependencies:
-  - %s
-`, darSymlink))
-
-		res := lo.Values(runResolveCommand(t).Packages)[0]
-
-		assert.Contains(t, res.GetResolvedDependencies()[0], "test.dar")
-	})
 }
 
 func ActivateDamlYamlForTest(t *testing.T, s string) (packageDir string) {

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -82,7 +82,7 @@ func (suite *MainSuite) TestResolutionOfFilePathBasedDarDependencies() {
 dependencies:
   - ./relative.dar
 data-dependencies:
-  - ./relative.dar
+  - relative.dar
 `))
 		os.WriteFile(
 			filepath.Join(packageDir, "relative.dar"),

--- a/pkg/damlpackage/locations.go
+++ b/pkg/damlpackage/locations.go
@@ -77,7 +77,7 @@ func (p *DamlPackage) parseLocations(ds []string, artifactLocations ArtifactLoca
 			// TODO
 			errs = append(errs, fmt.Errorf("couldn't parse dependency %q: http dependencies not yet supported", d))
 			continue
-		} else if isFilePath(d) {
+		} else if strings.HasSuffix(d, ".dar") {
 			absPath := utils.ResolvePath(filepath.Dir(p.AbsolutePath), d)
 			u, err := url.Parse("file://" + filepath.ToSlash(absPath))
 			if err != nil {
@@ -139,10 +139,4 @@ func (p *DamlPackage) parseLocations(ds []string, artifactLocations ArtifactLoca
 	}
 
 	return parsedLocations, nil
-}
-
-func isFilePath(s string) bool {
-	return strings.HasPrefix(s, ".") ||
-		strings.HasPrefix(s, "/") ||
-		strings.Index(s, ":") == 1
 }

--- a/pkg/resolver/deepresolver.go
+++ b/pkg/resolver/deepresolver.go
@@ -190,23 +190,8 @@ func (d *DeepResolver) resolvePackageDars(absPath string) (deps []string, dataDe
 func (d *DeepResolver) resolveDar(dar *damlpackage.ParsedDarDependency) ([]string, error) {
 	scheme := dar.FullUrl.Scheme
 
-	if scheme == "builtin" {
+	if scheme == "builtin" || scheme == "file" {
 		return []string{strings.TrimPrefix(dar.FullUrl.String(), scheme+"://")}, nil
-	}
-	if scheme == "file" {
-		f := strings.TrimPrefix(dar.FullUrl.String(), scheme+"://")
-		// verify the file exists
-		if _, err := os.Stat(f); err != nil {
-			return nil, fmt.Errorf("dar file doesn't exist: %w", err)
-		}
-
-		// evaluate symlink (if it is one)
-		evaluatedSymlink, err := filepath.EvalSymlinks(f)
-		if err != nil {
-			return nil, err
-		}
-
-		return []string{evaluatedSymlink}, nil
 	}
 	if scheme == "oci" {
 		_, ref, err := dar.GetOciRemote()


### PR DESCRIPTION
- stop checking for existence of (filepath-based) dars
- don't resolve symlink for `.dar`
- use `.dar` extension when deciding wether a dependency is filepath or something else

```
go run ../../cmd/dpm/main.go build --all
Running multi-package build of all packages in /Users/sammyabed/dpm/foo/myproject.

2026-06-08 14:37:29.35 [INFO]  [multi-package build]
Building /Users/sammyabed/dpm/foo/myproject/interfaces

2026-06-08 14:37:50.68 [INFO]  [build]
Compiling myproject-interfaces to a DAR.
File:     daml
Hidden:   no
Range:    1:1-2:1
Source:   Daml-LF typechecker
Severity: DsWarning
Message:
warning while type checking package:
  The following dependencies are not used:
   - 304ed37d213cc36e8ff27780426504a5925227609e130a3fa9f6f3b78047eb8a (daml-script, 3.5.1.20260502.14674.0)
  These dependencies can be removed from your daml.yaml
  Upgrade this warning to an error -Werror=unused-dependency
  Disable this warning entirely with -Wno-unused-dependency

2026-06-08 14:37:52.28 [INFO]  [build]
Created .daml/dist/myproject-interfaces-1.0.0.dar

2026-06-08 14:37:52.33 [INFO]  [multi-package build]
Building /Users/sammyabed/dpm/foo/myproject/main

2026-06-08 14:37:55.50 [INFO]  [build]
Compiling myproject-main to a DAR.
File:     daml
Hidden:   no
Range:    1:1-2:1
Source:   Daml-LF typechecker
Severity: DsWarning
Message:
warning while type checking package:
  The following dependencies are not used:
   - 304ed37d213cc36e8ff27780426504a5925227609e130a3fa9f6f3b78047eb8a (daml-script, 3.5.1.20260502.14674.0)
  These dependencies can be removed from your daml.yaml
  Upgrade this warning to an error -Werror=unused-dependency
  Disable this warning entirely with -Wno-unused-dependency

2026-06-08 14:37:56.96 [INFO]  [build]
Created .daml/dist/myproject-main-1.0.0.dar

2026-06-08 14:37:57.00 [INFO]  [multi-package build]
Building /Users/sammyabed/dpm/foo/myproject/test

2026-06-08 14:38:00.38 [INFO]  [build]
Compiling myproject-test to a DAR.

2026-06-08 14:38:01.90 [INFO]  [build]
Created .daml/dist/myproject-test-1.0.0.dar
```