### PR TITLE
ci: bump Node 20 action pins to Node 24 majors

### DIFF
--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -23,7 +23,7 @@ jobs:
       contents: write
       pull-requests: write    
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTO_REBASE_PAT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/nix
 
       - name: Run go build
@@ -46,8 +46,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.23.5'
       - run: go build -o target/ ./cmd/...
@@ -69,7 +69,7 @@ jobs:
       - linux
     if: success() && startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/tags/0.0.0-skiprelease'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - uses: ./.github/actions/release
@@ -85,7 +85,7 @@ jobs:
       - windows
       - linux
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/release
         with:
           # todo - update once decided moved to CF

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTO_REBASE_PAT }}


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout` from v4 (SHA `34e1148`) to v6.0.3 (SHA `df4cb1c`) across `build.yml`, `blackduck.yml`, and `comments.yml`
- Upgrades `actions/setup-go` from v5.6.0 (SHA `40f1582`) to v6.4.0 (SHA `4a36011`) in `build.yml`
- Adds missing version comments to SHA pins in `blackduck.yml` and `comments.yml`

## Test plan

- [ ] Verify CI passes on the PR (build, blackduck, comments workflows)
- [ ] Confirm no regressions in Go build and test steps