### PR TITLE
revamp 'dpm publish dar' command

### DIFF
--- a/cmd/dpm/cmd/artifacts_test.go
+++ b/cmd/dpm/cmd/artifacts_test.go
@@ -3,13 +3,14 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"io"
-	"oras.land/oras-go/v2"
 	"os"
 	"strings"
 	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/testutil"
@@ -33,7 +34,8 @@ func (suite *RepoSuite) TestPublishDar() {
 	cmd := createStdTestRootCmd(t)
 	args := []string{
 		"publish", "dar", fmt.Sprintf("oci://%s/meep:1.2.3", destinationRegistry),
-		"-f", testutil.TestdataPath(t, "test-dar"),
+		"-f", testutil.TestdataPath(t, "test-dar", "test.dar"),
+		"--license", testutil.TestdataPath(t, "test-dar", "LICENSE"),
 	}
 
 	if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
@@ -61,7 +63,7 @@ func (suite *RepoSuite) TestPublishLicenselessDar() {
 		cmd := createStdTestRootCmd(t)
 		args := []string{
 			"publish", "dar", fmt.Sprintf("oci://%s/meep:1.2.3", destinationRegistry),
-			"-f", testutil.TestdataPath(t, "licenseless-dar"), "--exclude-license",
+			"-f", testutil.TestdataPath(t, "licenseless-dar", "meep.dar"), "--exclude-license",
 		}
 
 		if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
@@ -100,7 +102,8 @@ func (suite *RepoSuite) TestPublishDarGenerateManifest() {
 		cmd := createStdTestRootCmd(t)
 		args := []string{
 			"publish", "dar", fmt.Sprintf("oci://%s/meep:1.2.3", destinationRegistry),
-			"-f", testutil.TestdataPath(t, "test-dar"),
+			"-f", testutil.TestdataPath(t, "test-dar", "test.dar"),
+			"--license", testutil.TestdataPath(t, "test-dar", "LICENSE"),
 		}
 
 		if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {
@@ -193,11 +196,9 @@ func (suite *RepoSuite) TestDarTags() {
 	t.Setenv(assistantconfig.DpmLockfileEnabledEnvVar, "true")
 	_, reg := testutil.StartRegistry(t)
 
-	args := testutil.PushDarUri(reg, fmt.Sprintf("%s/%s:%s", "foo/bar", "meep", "1.2.3"), testutil.TestdataPath(t, "test-dar"))
-	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
-
-	args = testutil.PushDarUri(reg, fmt.Sprintf("%s/%s:%s", "bar/foo", "meep", "1.2.4"), testutil.TestdataPath(t, "test-dar"))
-	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
+	regUrl := os.Getenv(assistantconfig.OciRegistryEnvVar)
+	pushDar(t, fmt.Sprintf("oci://%s/foo/bar/meep:1.2.3", regUrl))
+	pushDar(t, fmt.Sprintf("oci://%s/bar/foo/meep:1.2.4", regUrl))
 
 	t.Run("test tags for arbitrary repo", func(t *testing.T) {
 		res := listArtifactTags(t, "oci://"+strings.TrimPrefix(reg.URL, "http://")+"/foo/bar/meep")

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -182,7 +182,8 @@ artifact-locations:
 func pushDar(t *testing.T, uri string, extraTags ...string) {
 	args := []string{
 		"publish", "dar", uri,
-		"-f", testutil.TestdataPath(t, "test-dar"),
+		"-f", testutil.TestdataPath(t, "test-dar", "test.dar"),
+		"--license", testutil.TestdataPath(t, "test-dar", "LICENSE"),
 	}
 
 	if os.Getenv(assistantconfig.AllowInsecureRegistryEnvVar) == "true" {

--- a/cmd/dpm/cmd/publish/dar/dar.go
+++ b/cmd/dpm/cmd/publish/dar/dar.go
@@ -52,9 +52,14 @@ func Cmd() *cobra.Command {
 				},
 			}
 
+			if c.LicenseFile == "" && !c.ExcludeLicense {
+				return fmt.Errorf("must include a --license file or explicitly provide --exclude-license")
+			}
+
 			cmd.SilenceUsage = true
 			publishDarConfig := &publishdar.DarConfig{
-				File:           c.File,
+				Dars:           c.Dars,
+				LicenseFile:    c.LicenseFile,
 				Name:           name,
 				Version:        version,
 				DryRun:         c.DryRun,
@@ -64,7 +69,6 @@ func Cmd() *cobra.Command {
 				AuthFilePath:   c.RegistryAuth,
 				Insecure:       c.Insecure,
 				ExtraTags:      c.ExtraTags,
-				ExcludeLicense: c.ExcludeLicense,
 			}
 			return publishdar.New(publishDarConfig, cmd).PublishDar(cmd.Context())
 		},
@@ -73,8 +77,9 @@ func Cmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&c.DryRun, "dry-run", "d", false, "don't actually push to the registry")
 	cmd.Flags().BoolVarP(&c.IncludeGitInfo, "include-git-info", "g", false, "include git info as annotations on the published manifest")
 	cmd.Flags().StringToStringVarP(&c.Annotations, "annotations", "a", map[string]string{}, "annotations to include in the published OCI artifact")
+	cmd.Flags().StringVarP(&c.LicenseFile, "license", "l", "", "path to LICENSE file")
 	cmd.Flags().BoolVar(&c.ExcludeLicense, "exclude-license", false, "FOR NON-PRODUCTION USE: disable license file requirement for DAR publishing")
-	cmd.Flags().StringVarP(&c.File, "file", "f", "", `REQUIRED path to the dar file to publish`)
+	cmd.Flags().StringArrayVarP(&c.Dars, "dar", "f", nil, `REQUIRED path to the dar file to publish`)
 	cmd.MarkFlagRequired(publishcmd.FileFlagName)
 
 	cmd.Flags().StringSliceVarP(&c.ExtraTags, "extra-tags", "t", []string{}, "publish extra tags besides the semver")

--- a/docs-internal/src/cli/dpm_publish_dar.rst
+++ b/docs-internal/src/cli/dpm_publish_dar.rst
@@ -32,13 +32,14 @@ Options
 
   -a, --annotations stringToString   annotations to include in the published OCI artifact (default [])
       --auth string                  path to a config file similar to docker’s config.json to use for authenticating to the OCI registry. Defaults to docker's config.json
+  -f, --dar stringArray              REQUIRED path to the dar file to publish
   -d, --dry-run                      don't actually push to the registry
       --exclude-license              FOR NON-PRODUCTION USE: disable license file requirement for DAR publishing
   -t, --extra-tags strings           publish extra tags besides the semver
-  -f, --file string                  REQUIRED path to the dar file to publish
   -h, --help                         help for dar
   -g, --include-git-info             include git info as annotations on the published manifest
       --insecure                     use http instead of https for OCI registry
+  -l, --license string               path to LICENSE file
 
 SEE ALSO
 ~~~~~~~~

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -38,6 +38,8 @@ const (
 
 	// SkipLegacyOciAnnotationsEnvVar will skip attaching legacy annotations when publishing oci manifests
 	SkipLegacyOciAnnotationsEnvVar = "SKIP_LEGACY_OCI_ANNOTATIONS"
+
+	DescriptorMainPackageIdAnnotation = DpmAnnotationPrefix + "main-package-id"
 )
 
 // DescriptorAnnotations are required annotations to be appended onto image and index manifests.

--- a/pkg/ocipusher/darpusher/darpusher.go
+++ b/pkg/ocipusher/darpusher/darpusher.go
@@ -7,11 +7,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log/slog"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"daml.com/x/assistant/pkg/darmanifest"
 	"daml.com/x/assistant/pkg/schema"
@@ -29,18 +28,17 @@ import (
 	"daml.com/x/assistant/pkg/utils/fileinfo"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
 )
 
 type DarOpts struct {
-	Artifact oci.Artifact
-	Version  semver.Version
-	Dir      string
+	Artifact    oci.Artifact
+	Version     semver.Version
+	Dars        []string
+	LicenseFile string
 }
 
 type DarPushOperation struct {
-	fs           *file.Store
 	ms           *memory.Store
 	manifestDesc *v1.Descriptor
 	repoName     string
@@ -59,67 +57,38 @@ func DarNew(ctx context.Context, opts DarOpts) (*DarPushOperation, error) {
 	repoName := opts.Artifact.RepoName()
 
 	ms := memory.New()
-	fs, err := file.New(opts.Dir)
-	if err != nil {
-		return nil, err
-	}
-
-	dEntries, err := os.ReadDir(opts.Dir)
-	if err != nil {
-		return nil, err
-	}
-
 	var fileDescriptors []v1.Descriptor
-	var darName string
-	for _, de := range dEntries {
-		fileDescriptor, err := fs.Add(ctx, de.Name(), opts.Artifact.FileMediaType(), "")
-		if err != nil {
-			return nil, err
-		}
+	var errs []error
 
-		if strings.HasSuffix(de.Name(), ".dar") {
-			if darName != "" {
-				return nil, fmt.Errorf("found multiple dars in the given directory. Currently only one dar is support")
-			}
-			darName = de.Name()
-		}
-		osFileInfo, err := de.Info()
-		if err != nil {
-			return nil, err
-		}
-
-		fileInfoAnnotations := fileinfo.New(osFileInfo).AsAnnotations()
-		appendAnnotations(fileDescriptor, fileInfoAnnotations)
-
-		fileBytes, err := os.ReadFile(filepath.Join(opts.Dir, de.Name()))
-		if err != nil {
-			return nil, err
-		}
-
-		if err := ms.Push(ctx, fileDescriptor, bytes.NewReader(fileBytes)); err != nil {
-			return nil, err
-		}
-		fileDescriptors = append(fileDescriptors, fileDescriptor)
-	}
-	if darName == "" {
-		slog.ErrorContext(ctx, "No file ending in .dar found")
-		return nil, fmt.Errorf("missing .dar file")
-	}
-
-	mainDalfHash, err := GetMainPackageId(filepath.Join(opts.Dir, darName))
-	if err != nil {
-		return nil, err
-	}
 	darManifest := darmanifest.DarManifest{
 		ManifestMeta: schema.ManifestMeta{
 			APIVersion: darmanifest.DarAPIVersion,
 			Kind:       darmanifest.DarKind,
 		},
 		Spec: &darmanifest.Spec{
-			Dars: []darmanifest.Dar{
-				{Path: darName, MainPackageId: mainDalfHash},
-			},
+			Dars: []darmanifest.Dar{},
 		},
+	}
+
+	for _, darPath := range opts.Dars {
+		mainPackageId, err := GetMainPackageId(darPath)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		darManifest.Spec.Dars = append(darManifest.Spec.Dars, darmanifest.Dar{
+			Path:          filepath.Base(darPath),
+			MainPackageId: mainPackageId,
+		})
+
+		darFileDescriptor, err := opts.mkDescriptorForFile(ctx, ms, darPath)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		darFileDescriptor.Annotations[oci.DescriptorMainPackageIdAnnotation] = mainPackageId
+
+		fileDescriptors = append(fileDescriptors, darFileDescriptor)
 	}
 
 	darManifestDescriptor, err := createDarManifestDescriptor(ctx, ms, opts, darManifest)
@@ -127,6 +96,15 @@ func DarNew(ctx context.Context, opts DarOpts) (*DarPushOperation, error) {
 		return nil, err
 	}
 	fileDescriptors = append(fileDescriptors, *darManifestDescriptor)
+
+	// license file
+	if opts.LicenseFile != "" {
+		desc, err := opts.mkDescriptorForFile(ctx, ms, opts.LicenseFile)
+		if err != nil {
+			return nil, err
+		}
+		fileDescriptors = append(fileDescriptors, desc)
+	}
 
 	annotations := map[string]string{}
 	annotations[v1.AnnotationVersion] = opts.Version.String()
@@ -144,7 +122,6 @@ func DarNew(ctx context.Context, opts DarOpts) (*DarPushOperation, error) {
 	op := &DarPushOperation{
 		repoName:     repoName,
 		rawTag:       opts.Version.String(),
-		fs:           fs,
 		ms:           ms,
 		manifestDesc: &manifestDescriptor,
 	}
@@ -173,9 +150,6 @@ func (op *DarPushOperation) DarDo(ctx context.Context, client *assistantremote.R
 		return nil, err
 	}
 
-	if err := op.fs.Close(); err != nil {
-		return nil, err
-	}
 	return &d, err
 }
 
@@ -206,4 +180,43 @@ func createDarManifestDescriptor(ctx context.Context, mem *memory.Store, opts Da
 	}
 
 	return &desc, nil
+}
+
+func (opts DarOpts) mkDescriptorForFile(ctx context.Context, mem *memory.Store, filePath string) (v1.Descriptor, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return v1.Descriptor{}, err
+	}
+	defer func() { _ = f.Close() }()
+
+	fileInfo, err := f.Stat()
+	if err != nil {
+		return v1.Descriptor{}, err
+	}
+
+	if !fileInfo.Mode().IsRegular() {
+		return v1.Descriptor{}, fmt.Errorf("invalid file %q. Only regular files allowed", filePath)
+	}
+
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return v1.Descriptor{}, err
+	}
+
+	desc := ocispec.Descriptor{
+		MediaType: opts.Artifact.FileMediaType(),
+		Digest:    digest.FromBytes(content),
+		Size:      fileInfo.Size(),
+		Annotations: map[string]string{
+			ocispec.AnnotationTitle: filepath.Base(filePath),
+		},
+	}
+
+	fileInfoAnnotations := fileinfo.New(fileInfo).AsAnnotations()
+	appendAnnotations(desc, fileInfoAnnotations)
+
+	if err := mem.Push(ctx, desc, bytes.NewReader(content)); err != nil {
+		return v1.Descriptor{}, err
+	}
+	return desc, nil
 }

--- a/pkg/publishcmd/publishcmd.go
+++ b/pkg/publishcmd/publishcmd.go
@@ -10,7 +10,7 @@ import (
 )
 
 const PlatformFlagName = "platform"
-const FileFlagName = "file"
+const FileFlagName = "dar"
 
 type PublishCmd struct {
 	DryRun, IncludeGitInfo bool
@@ -30,9 +30,10 @@ type PublishDarCmd struct {
 	Name                   string
 	Version                string
 	Annotations            map[string]string
-	File                   string
+	Dars                   []string
 	ExtraTags              []string
 	ExcludeLicense         bool
+	LicenseFile            string
 
 	Insecure     bool
 	Registry     string

--- a/pkg/publishdar/publishdar.go
+++ b/pkg/publishdar/publishdar.go
@@ -9,12 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"os"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 
 	"daml.com/x/assistant/pkg/assistantconfig/assistantremote"
-	"daml.com/x/assistant/pkg/licenseutils"
 	ociconsts "daml.com/x/assistant/pkg/oci"
 	"daml.com/x/assistant/pkg/ociindex"
 	"daml.com/x/assistant/pkg/ocilister"
@@ -25,18 +24,17 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/samber/lo"
 	"oras.land/oras-go/v2/errdef"
 )
 
 type DarConfig struct {
 	Name                   string
-	File                   string
+	Dars                   []string
 	Version                *semver.Version
 	DryRun, IncludeGitInfo bool
 	Annotations            map[string]string
 	ExtraTags              []string
-	ExcludeLicense         bool
+	LicenseFile            string
 
 	Destination  *publish.Destination
 	AuthFilePath string
@@ -54,7 +52,7 @@ func New(config *DarConfig, printer utils.RawPrinter) *DarPublisher {
 
 func (p *DarPublisher) PublishDar(ctx context.Context) (err error) {
 	var pushOp *darpusher.DarPushOperation
-	pushOp, err = p.prepareDar(ctx, p.config.File)
+	pushOp, err = p.prepare(ctx)
 	if err != nil {
 		return err
 	}
@@ -97,21 +95,13 @@ func (p *DarPublisher) PublishDar(ctx context.Context) (err error) {
 	return nil
 }
 
-func (p *DarPublisher) prepareDar(ctx context.Context, dir string) (*darpusher.DarPushOperation, error) {
-	if p.config.ExcludeLicense {
-		p.printer.Println("FOR TESTING ONLY: Skipping license file check due to --exclude-license flag being set")
-	} else {
-		p.printer.Printf("📦 Checking %q includes license file...\n", dir)
-		if err := checkHasLicense(dir); err != nil {
-			return nil, err
+func (p *DarPublisher) prepare(ctx context.Context) (*darpusher.DarPushOperation, error) {
+	for _, darFilePath := range p.config.Dars {
+		if !strings.HasSuffix(darFilePath, ".dar") {
+			return nil, fmt.Errorf("provided dar file %q is invalid. Must end with .dar extension", darFilePath)
 		}
-		p.printer.Printf("License file included ✅\n")
-		p.printer.Println()
 	}
-	return p.prepare(ctx, dir)
-}
 
-func (p *DarPublisher) prepare(ctx context.Context, dir string) (*darpusher.DarPushOperation, error) {
 	annotations := maps.Clone(p.config.Annotations)
 	if p.config.IncludeGitInfo {
 		gitAnnotations, err := collectGitAnnotations()
@@ -124,9 +114,10 @@ func (p *DarPublisher) prepare(ctx context.Context, dir string) (*darpusher.DarP
 	artifact = &ociconsts.DarArtifact{DarRepo: p.config.Destination.Artifact.RepoName()}
 
 	opts := darpusher.DarOpts{
-		Artifact: artifact,
-		Version:  *p.config.Version,
-		Dir:      dir,
+		Artifact:    artifact,
+		Version:     *p.config.Version,
+		Dars:        p.config.Dars,
+		LicenseFile: p.config.LicenseFile,
 	}
 
 	pushOp, err := darpusher.DarNew(ctx, opts)
@@ -156,20 +147,6 @@ func (p *DarPublisher) push(ctx context.Context, client *assistantremote.Remote,
 	p.printer.Printf("\n%s\n", string(descriptorJson))
 	p.printer.Println("successfully published " + coloredDest)
 	return descriptor, nil
-}
-
-func checkHasLicense(dir string) error {
-	des, err := os.ReadDir(dir)
-	if err != nil {
-		return err
-	}
-	_, ok := lo.Find(des, func(de os.DirEntry) bool {
-		return de.Name() == licenseutils.ComponentLicenseFilename && de.Type().IsRegular()
-	})
-	if !ok {
-		return fmt.Errorf("required %s file is missing at component root (%q)", licenseutils.ComponentLicenseFilename, dir)
-	}
-	return nil
 }
 
 func (p *DarPublisher) checkVersionExists(ctx context.Context, op *darpusher.DarPushOperation, client *assistantremote.Remote) (bool, error) {


### PR DESCRIPTION
- Command no longer takes a dir as single argument, but multiple args instead:
```
dpm publish dar oci://<uri> \
   -f  /some/path/some-dar.dar  \
   -f  /some/path/another-dar.dar  \
   --license ./LICENSE
```
- Include main-package-id annotation on each dar's layer in the OCI image  
