### PR TITLE
add `main-package-id` field in daml.yaml

### DIFF
--- a/pkg/damlpackage/damlproject.go
+++ b/pkg/damlpackage/damlproject.go
@@ -27,8 +27,8 @@ type DamlPackage struct {
 	// deprecated in favor of Components
 	DeprecatedOverrideComponents map[string]*sdkmanifest.Component `yaml:"override-components,omitempty"`
 
-	Dependencies          []string               `yaml:"dependencies,omitempty"`
-	DataDependencies      []string               `yaml:"data-dependencies,omitempty"`
+	Dependencies          []*RawDependency       `yaml:"dependencies,omitempty"`
+	DataDependencies      []*RawDependency       `yaml:"data-dependencies,omitempty"`
 	ArtifactLocations     ArtifactLocations      `yaml:"artifact-locations,omitempty"`
 	ParsedDarDependencies *ParsedDarDependencies `yaml:"-"`
 

--- a/pkg/damlpackage/locations.go
+++ b/pkg/damlpackage/locations.go
@@ -31,6 +31,8 @@ type ParsedDarDependency struct {
 
 	// can be nil when the corresponding dependency is already fully qualified and doesn't rely on an artifact-location
 	Location *ArtifactLocation
+
+	MainPackageId *string
 }
 
 func (d *ParsedDarDependency) GetOciRemote() (*assistantremote.Remote, *registry.Reference, error) {
@@ -60,19 +62,25 @@ func (d *ParsedDarDependency) GetOciRemote() (*assistantremote.Remote, *registry
 
 var regex = regexp.MustCompile(`^(@[a-zA-Z0-9_-]+)/`)
 
-func (p *DamlPackage) parseLocations(ds []string, artifactLocations ArtifactLocations) (map[string]*ParsedDarDependency, error) {
+func (p *DamlPackage) parseLocations(rawDeps []*RawDependency, artifactLocations ArtifactLocations) (map[string]*ParsedDarDependency, error) {
 	parsedLocations := map[string]*ParsedDarDependency{}
 
 	var errs []error
 
-	for _, d := range ds {
+	for _, rawDep := range rawDeps {
+		d, err := rawDep.Value()
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
 		if strings.HasPrefix(d, "oci://") {
 			u, err := url.Parse(d)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("couldn't parse dependency url %q: %w", d, err))
 				continue
 			}
-			parsedLocations[d] = &ParsedDarDependency{FullUrl: u}
+			parsedLocations[d] = &ParsedDarDependency{FullUrl: u, MainPackageId: rawDep.GetMainPackageId()}
 		} else if strings.HasPrefix(d, "http://") || strings.HasPrefix(d, "https://") {
 			// TODO
 			errs = append(errs, fmt.Errorf("couldn't parse dependency %q: http dependencies not yet supported", d))
@@ -85,8 +93,9 @@ func (p *DamlPackage) parseLocations(ds []string, artifactLocations ArtifactLoca
 				continue
 			}
 			parsedLocations[d] = &ParsedDarDependency{
-				Location: nil,
-				FullUrl:  u,
+				Location:      nil,
+				FullUrl:       u,
+				MainPackageId: rawDep.GetMainPackageId(),
 			}
 		} else if strings.HasPrefix(d, "@") {
 			parsed := regex.FindStringSubmatch(d)
@@ -112,8 +121,9 @@ func (p *DamlPackage) parseLocations(ds []string, artifactLocations ArtifactLoca
 				continue
 			}
 			parsedLocations[d] = &ParsedDarDependency{
-				Location: location,
-				FullUrl:  u,
+				Location:      location,
+				FullUrl:       u,
+				MainPackageId: rawDep.GetMainPackageId(),
 			}
 		} else if strings.Contains(d, ":") {
 			errs = append(errs, fmt.Errorf("error parsing dependency %q: OCI dependencies must start with oci://", d))
@@ -128,8 +138,9 @@ func (p *DamlPackage) parseLocations(ds []string, artifactLocations ArtifactLoca
 				continue
 			}
 			parsedLocations[d] = &ParsedDarDependency{
-				Location: nil,
-				FullUrl:  u,
+				Location:      nil,
+				FullUrl:       u,
+				MainPackageId: rawDep.GetMainPackageId(),
 			}
 		}
 	}

--- a/pkg/damlpackage/rawdependency.go
+++ b/pkg/damlpackage/rawdependency.go
@@ -1,0 +1,66 @@
+package damlpackage
+
+import (
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+)
+
+var RawDependenciesSchemaErr = fmt.Errorf("dar dependencies fields must be of type string or '{ value: <string>, main-package-id: <string> }' object")
+
+// RawDependency is the 'string | {...}' sum-type for
+// dependencies / data-dependencies YAML fields
+type RawDependency struct {
+	ValueOnly     *string
+	WithPackageId *withPackageId
+}
+
+type withPackageId struct {
+	Value         string `yaml:"value"`
+	MainPackageId string `yaml:"main-package-id"`
+}
+
+func (r *RawDependency) Value() (string, error) {
+	switch {
+	case r.WithPackageId != nil:
+		return r.WithPackageId.Value, nil
+	case r.ValueOnly != nil:
+		return *r.ValueOnly, nil
+	default:
+		return "", RawDependenciesSchemaErr
+	}
+}
+
+func (r *RawDependency) GetMainPackageId() *string {
+	if r.WithPackageId == nil {
+		return nil
+	}
+	return &r.WithPackageId.MainPackageId
+}
+
+func (r *RawDependency) UnmarshalYAML(b []byte) error {
+	var s string
+	if err := yaml.Unmarshal(b, &s); err == nil {
+		r.ValueOnly = &s
+		return nil
+	}
+
+	var obj withPackageId
+	if err := yaml.Unmarshal(b, &obj); err == nil {
+		r.WithPackageId = &obj
+		return nil
+	}
+
+	return RawDependenciesSchemaErr
+}
+
+func (r *RawDependency) MarshalYAML() (any, error) {
+	switch {
+	case r.WithPackageId != nil:
+		return *r.WithPackageId, nil
+	case r.ValueOnly != nil:
+		return r.ValueOnly, nil
+	default:
+		return nil, nil
+	}
+}


### PR DESCRIPTION
makes `dependencies` / `data-dependencies` fields in `daml.yaml` be a sum-type:
```
dependencies:
  - daml-script
  - oci://stuff
  - value: oci://stuff
    main-package-id: asdfasdfads12345asfasfdds
```