### PR TITLE
dpm add dar command

### DIFF
--- a/cmd/dpm/cmd/add/add.go
+++ b/cmd/dpm/cmd/add/add.go
@@ -2,6 +2,7 @@ package add
 
 import (
 	"daml.com/x/assistant/cmd/dpm/cmd/add/component"
+	"daml.com/x/assistant/cmd/dpm/cmd/add/dar"
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"github.com/spf13/cobra"
 )
@@ -13,5 +14,6 @@ func Cmd(config *assistantconfig.Config) *cobra.Command {
 	}
 
 	cmd.AddCommand(component.Cmd(config))
+	cmd.AddCommand(dar.Cmd(config))
 	return cmd
 }

--- a/cmd/dpm/cmd/add/dar/dar.go
+++ b/cmd/dpm/cmd/add/dar/dar.go
@@ -1,0 +1,96 @@
+package dar
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	project "daml.com/x/assistant/cmd/dpm/cmd/install/package"
+	"daml.com/x/assistant/pkg/assistantconfig"
+	"daml.com/x/assistant/pkg/assistantconfig/assistantremote"
+	"daml.com/x/assistant/pkg/damlpackage"
+	"daml.com/x/assistant/pkg/ocilister"
+	"daml.com/x/assistant/pkg/yamledit"
+	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2/registry"
+)
+
+func Cmd(config *assistantconfig.Config) *cobra.Command {
+	var insecure bool
+
+	cmd := &cobra.Command{
+		Use:    "dar <oci-uri>",
+		Short:  "add a dar to project",
+		Args:   cobra.ExactArgs(1),
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			uri := args[0]
+
+			damlPackage, ok, err := assistantconfig.GetDamlPackageAbsolutePath()
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("must be in daml.yaml directory or sub-directory")
+			}
+
+			ref, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
+			if err != nil {
+				return err
+			}
+			client, err := assistantremote.New(ref.Registry, "", insecure)
+			if err != nil {
+				return err
+			}
+
+			// Resolve to sha256
+			ociManifest, err := ocilister.FetchManifest(ctx, client, ref)
+			if err != nil {
+				return err
+			}
+			resolvedUri := uri + "@" + ociManifest.Digest.String()
+
+			// Pull
+			parsedUrl, err := url.Parse(resolvedUri)
+			if err != nil {
+				return err
+			}
+			parsedDarDep := &damlpackage.ParsedDarDependency{
+				FullUrl: parsedUrl,
+				Location: &damlpackage.ArtifactLocation{
+					Insecure: insecure,
+				},
+			}
+			if err := project.InstallDar(ctx, config, parsedDarDep); err != nil {
+				return err
+			}
+
+			// Edit daml.yaml
+			if err := appendDarToYaml(damlPackage, resolvedUri); err != nil {
+				return err
+			}
+
+			fmt.Printf("Successfully installed and added dar %q to %q\n", resolvedUri, damlPackage)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&insecure, "insecure", false, "use http instead of https for OCI registry")
+
+	return cmd
+}
+
+func appendDarToYaml(path, dar string) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	out, err := yamledit.AddToList(b, "data-dependencies", dar)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(out), 0644)
+}

--- a/cmd/dpm/cmd/dpm_add_test.go
+++ b/cmd/dpm/cmd/dpm_add_test.go
@@ -16,7 +16,7 @@ import (
 func (suite *MainSuite) TestDpmAddComponentCommand() {
 	t := suite.T()
 
-	os.Setenv(assistantconfig.DpmShaPinningEnabled, "true")
+	t.Setenv(assistantconfig.DpmShaPinningEnabled, "true")
 
 	_, reg := testutil.StartRegistry(t)
 	newComponentRepo := "newly/added:4.5.6"
@@ -59,7 +59,7 @@ components:
 func (suite *MainSuite) TestDpmAddDarCommand() {
 	t := suite.T()
 
-	os.Setenv(assistantconfig.DpmShaPinningEnabled, "true")
+	t.Setenv(assistantconfig.DpmShaPinningEnabled, "true")
 
 	testutil.StartRegistry(t)
 	reg := os.Getenv(assistantconfig.OciRegistryEnvVar)

--- a/cmd/dpm/cmd/dpm_add_test.go
+++ b/cmd/dpm/cmd/dpm_add_test.go
@@ -16,7 +16,7 @@ import (
 func (suite *MainSuite) TestDpmAddComponentCommand() {
 	t := suite.T()
 
-	os.Setenv(assistantconfig.DpmFloatiesEnabled, "true")
+	os.Setenv(assistantconfig.DpmShaPinningEnabled, "true")
 
 	_, reg := testutil.StartRegistry(t)
 	newComponentRepo := "newly/added:4.5.6"
@@ -59,7 +59,7 @@ components:
 func (suite *MainSuite) TestDpmAddDarCommand() {
 	t := suite.T()
 
-	os.Setenv(assistantconfig.DpmFloatiesEnabled, "true")
+	os.Setenv(assistantconfig.DpmShaPinningEnabled, "true")
 
 	testutil.StartRegistry(t)
 	reg := os.Getenv(assistantconfig.OciRegistryEnvVar)

--- a/cmd/dpm/cmd/dpm_add_test.go
+++ b/cmd/dpm/cmd/dpm_add_test.go
@@ -6,13 +6,17 @@ import (
 	"path/filepath"
 	"testing"
 
+	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/registry"
 )
 
 func (suite *MainSuite) TestDpmAddComponentCommand() {
 	t := suite.T()
+
+	os.Setenv(assistantconfig.DpmFloatiesEnabled, "true")
 
 	_, reg := testutil.StartRegistry(t)
 	newComponentRepo := "newly/added:4.5.6"
@@ -50,4 +54,32 @@ components:
 		require.NoError(t, err)
 		assert.Contains(t, string(newContent), "- "+newComponent+"@sha256:")
 	})
+}
+
+func (suite *MainSuite) TestDpmAddDarCommand() {
+	t := suite.T()
+
+	os.Setenv(assistantconfig.DpmFloatiesEnabled, "true")
+
+	testutil.StartRegistry(t)
+	reg := os.Getenv(assistantconfig.OciRegistryEnvVar)
+
+	darRef, err := registry.ParseReference(fmt.Sprintf("%s/newly/added:4.5.6", reg))
+	require.NoError(t, err)
+	pushDar(t, "oci://"+darRef.String())
+
+	t.Run("add new dar in single-package project", func(t *testing.T) {
+		projectDir := testutil.ActivateDamlYamlForTest(t, `
+data-dependencies:
+  - std-lib
+`)
+
+		cmd := createStdTestRootCmd(t, "add", "dar", "oci://"+darRef.String(), "--insecure")
+		require.NoError(t, cmd.Execute())
+
+		newContent, err := os.ReadFile(filepath.Join(projectDir, "daml.yaml"))
+		require.NoError(t, err)
+		assert.Contains(t, string(newContent), "- oci://"+darRef.String()+"@sha256:")
+	})
+
 }

--- a/cmd/dpm/cmd/install/package/package.go
+++ b/cmd/dpm/cmd/install/package/package.go
@@ -145,10 +145,10 @@ func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpa
 	}
 
 	if assistantconfig.ShaPinningEnabled() {
-		if !strings.HasPrefix(ref.Reference, "@sha256:") {
+		if !strings.Contains(ref.Reference, "sha256:") {
 			// TODO support having `dpm install` resolve to sha256
 			// when the dar uri in daml.yaml doesn't already include it
-			return fmt.Errorf("currently, dar oci URIs in daml.yaml must include @sha256. Prefer 'dpm add dar' command to add dars to your daml.yaml")
+			return fmt.Errorf("currently 'dpm install' requires dar oci URIs in daml.yaml to include '@sha256'. Prefer 'dpm add dar' command to add dars to your daml.yaml")
 		}
 	}
 

--- a/cmd/dpm/cmd/install/package/package.go
+++ b/cmd/dpm/cmd/install/package/package.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"daml.com/x/assistant/pkg/assembler"
 	"daml.com/x/assistant/pkg/assembler/assemblyplan"
@@ -141,6 +142,14 @@ func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpa
 
 	if !assistantconfig.ShaPinningEnabled() && ocilister.IsFloaty(ref.Reference) {
 		return fmt.Errorf("tag not allowed in %q: only strict semver OCI tags are supported currently", dar.FullUrl.String())
+	}
+
+	if assistantconfig.ShaPinningEnabled() {
+		if !strings.HasPrefix(ref.Reference, "@sha256:") {
+			// TODO support having `dpm install` resolve to sha256
+			// when the dar uri in daml.yaml doesn't already include it
+			return fmt.Errorf("currently, dar oci URIs in daml.yaml must include @sha256. Prefer 'dpm add dar' command to add dars to your daml.yaml")
+		}
 	}
 
 	puller := remotepuller.New(config.OciLayoutCache, client)

--- a/cmd/dpm/cmd/install/package/package.go
+++ b/cmd/dpm/cmd/install/package/package.go
@@ -121,14 +121,14 @@ func processDamlPackage(ctx context.Context, cmd *cobra.Command, config *assista
 
 func installDars(ctx context.Context, config *assistantconfig.Config, dars []*damlpackage.ParsedDarDependency) error {
 	for _, d := range dars {
-		if err := installDar(ctx, config, d); err != nil {
+		if err := InstallDar(ctx, config, d); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func installDar(ctx context.Context, config *assistantconfig.Config, dar *damlpackage.ParsedDarDependency) error {
+func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpackage.ParsedDarDependency) error {
 	if dar.FullUrl.Scheme != "oci" {
 		return nil
 	}
@@ -139,7 +139,7 @@ func installDar(ctx context.Context, config *assistantconfig.Config, dar *damlpa
 		return err
 	}
 
-	if ocilister.IsFloaty(ref.Reference) {
+	if !assistantconfig.ShaPinningEnabled() && ocilister.IsFloaty(ref.Reference) {
 		return fmt.Errorf("tag not allowed in %q: only strict semver OCI tags are supported currently", dar.FullUrl.String())
 	}
 

--- a/pkg/assistantconfig/config.go
+++ b/pkg/assistantconfig/config.go
@@ -379,11 +379,11 @@ func DpmLockfileEnabled() bool {
 }
 
 func ShaPinningEnabled() bool {
-	return os.Getenv(DpmFloatiesEnabled) == "true"
+	return os.Getenv(DpmShaPinningEnabled) == "true"
 }
 
 func (c *Config) CachePathForDar(ref *registry.Reference) string {
-	if strings.HasPrefix(ref.Reference, "@sha256:") {
+	if ShaPinningEnabled() && strings.HasPrefix(ref.Reference, "@sha256:") {
 		return filepath.Join(c.CachePath, "dars", "sha256", strings.TrimPrefix(ref.Reference, "@sha256:"))
 	}
 	return filepath.Join(c.CachePath, "dars", utils.UrlToFilePath(fmt.Sprintf("%s/%s", ref.Registry, ref.Repository)), ref.Reference)

--- a/pkg/assistantconfig/config.go
+++ b/pkg/assistantconfig/config.go
@@ -378,6 +378,10 @@ func DpmLockfileEnabled() bool {
 	return os.Getenv(DpmLockfileEnabledEnvVar) == "true"
 }
 
+func ShaPinningEnabled() bool {
+	return os.Getenv(DpmFloatiesEnabled) == "true"
+}
+
 func (c *Config) CachePathForDar(ref *registry.Reference) string {
 	return filepath.Join(c.CachePath, "dars", utils.UrlToFilePath(fmt.Sprintf("%s/%s", ref.Registry, ref.Repository)), ref.Reference)
 }

--- a/pkg/assistantconfig/config.go
+++ b/pkg/assistantconfig/config.go
@@ -383,8 +383,9 @@ func ShaPinningEnabled() bool {
 }
 
 func (c *Config) CachePathForDar(ref *registry.Reference) string {
-	if ShaPinningEnabled() && strings.HasPrefix(ref.Reference, "@sha256:") {
-		return filepath.Join(c.CachePath, "dars", "sha256", strings.TrimPrefix(ref.Reference, "@sha256:"))
+	if ShaPinningEnabled() {
+		sha := strings.ReplaceAll(ref.Reference, "sha256:", "")
+		return filepath.Join(c.CachePath, "dars", "sha256", sha)
 	}
 	return filepath.Join(c.CachePath, "dars", utils.UrlToFilePath(fmt.Sprintf("%s/%s", ref.Registry, ref.Repository)), ref.Reference)
 }

--- a/pkg/assistantconfig/config.go
+++ b/pkg/assistantconfig/config.go
@@ -383,5 +383,8 @@ func ShaPinningEnabled() bool {
 }
 
 func (c *Config) CachePathForDar(ref *registry.Reference) string {
+	if strings.HasPrefix(ref.Reference, "@sha256:") {
+		return filepath.Join(c.CachePath, "dars", "sha256", strings.TrimPrefix(ref.Reference, "@sha256:"))
+	}
 	return filepath.Join(c.CachePath, "dars", utils.UrlToFilePath(fmt.Sprintf("%s/%s", ref.Registry, ref.Repository)), ref.Reference)
 }

--- a/pkg/assistantconfig/envvars.go
+++ b/pkg/assistantconfig/envvars.go
@@ -67,5 +67,5 @@ const (
 
 	DpmLockfileEnabledEnvVar = "DPM_LOCKFILE_ENABLED"
 
-	DpmFloatiesEnabled = "DPM_FLOATIES_ENABLED"
+	DpmShaPinningEnabled = "DPM_SHA_PINNING_ENABLED"
 )

--- a/pkg/assistantconfig/envvars.go
+++ b/pkg/assistantconfig/envvars.go
@@ -66,4 +66,6 @@ const (
 	DpmSdkVersionEnvVar = "DPM_SDK_VERSION"
 
 	DpmLockfileEnabledEnvVar = "DPM_LOCKFILE_ENABLED"
+
+	DpmFloatiesEnabled = "DPM_FLOATIES_ENABLED"
 )

--- a/pkg/ocilister/lister.go
+++ b/pkg/ocilister/lister.go
@@ -5,6 +5,7 @@ package ocilister
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"regexp"
@@ -14,7 +15,10 @@ import (
 	"daml.com/x/assistant/pkg/ociindex"
 	"daml.com/x/assistant/pkg/sdkmanifest"
 	"github.com/Masterminds/semver/v3"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/samber/lo"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote/errcode"
 )
 
@@ -113,4 +117,33 @@ func Cmp(a, b *semver.Version) int {
 func isErrorCode(err error, code string) bool {
 	var ec errcode.Error
 	return errors.As(err, &ec) && ec.Code == code
+}
+
+func FetchManifest(ctx context.Context, client *assistantremote.Remote, ref registry.Reference) (*v1.Descriptor, error) {
+	repo, err := client.Repo(ref.Repository)
+	if err != nil {
+		return nil, err
+	}
+	desc, err := repo.Resolve(ctx, ref.Reference)
+	if err != nil {
+		return nil, err
+	}
+
+	rc, err := repo.Fetch(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	manifestBytes, err := content.ReadAll(rc, desc)
+	if err != nil {
+		return nil, err
+	}
+
+	var manifest v1.Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return nil, err
+	}
+
+	return &desc, nil
 }


### PR DESCRIPTION
- `dpm add dar` command
- added a  feat flag to allow opt-in DARs to be floaty tags and for storing dars by sha256 only in the cache