### PR TITLE
'dpm add component' should sometimes update

### DIFF
--- a/cmd/dpm/cmd/add/component/component.go
+++ b/cmd/dpm/cmd/add/component/component.go
@@ -1,15 +1,19 @@
 package component
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"os"
 	"strings"
 
+	"daml.com/x/assistant/cmd/dpm/cmd/add/dar"
 	"daml.com/x/assistant/pkg/assembler"
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/assistantconfig/assistantremote"
 	"daml.com/x/assistant/pkg/componentlist"
+	"daml.com/x/assistant/pkg/damlpackage"
+	"daml.com/x/assistant/pkg/multipackage"
 	"daml.com/x/assistant/pkg/ocipuller/remotepuller"
 	"daml.com/x/assistant/pkg/sdkmanifest"
 	"daml.com/x/assistant/pkg/yamledit"
@@ -32,45 +36,70 @@ func Cmd(config *assistantconfig.Config) *cobra.Command {
 			ctx := cmd.Context()
 			uri := args[0]
 
-			projectManifest, err := getDamlYamlOrMultiPackageYaml()
+			damlPackagePath, multiPackagePath, err := getDamlYamlOrMultiPackageYaml()
 			if err != nil {
 				return err
 			}
+			projectManifest := cmp.Or(damlPackagePath, multiPackagePath)
 
-			ref, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
-			if err != nil {
-				return err
-			}
-			client, err := assistantremote.New(ref.Registry, "", insecure)
-			if err != nil {
-				return err
-			}
-
-			// Resolve to sha256
-			sha, err := GetDigest(ctx, client, ref)
-			if err != nil {
-				return err
-			}
-			resolvedUri := uri + "@" + sha.String()
-
-			// Pull
-			if err := PullComponent(ctx, resolvedUri, config, client); err != nil {
-				return err
+			var components componentlist.ComponentList
+			if damlPackagePath != "" {
+				obj, err := damlpackage.Read(damlPackagePath)
+				if err != nil {
+					return err
+				}
+				components = obj.ComponentsList
+			} else {
+				obj, err := multipackage.Read(multiPackagePath)
+				if err != nil {
+					return err
+				}
+				components = obj.ComponentsList
 			}
 
-			// Edit daml.yaml / multi-package.yaml
-			if err := appendComponentToYaml(projectManifest, resolvedUri); err != nil {
-				return err
+			index := findExistingComponent(components, uri)
+			if index != -1 {
+				fmt.Printf("component %q already exists, will be updated...\n", uri)
 			}
 
-			fmt.Printf("Successfully installed and added component %q to %q\n", resolvedUri, projectManifest)
-			return nil
+			return AddOrUpdateComponent(ctx, config, projectManifest, uri, insecure, index)
 		},
 	}
 
 	cmd.Flags().BoolVar(&insecure, "insecure", false, "use http instead of https for OCI registry")
 
 	return cmd
+}
+
+func AddOrUpdateComponent(ctx context.Context, config *assistantconfig.Config, projectManifest, uri string, insecure bool, index int) error {
+	ref, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
+	if err != nil {
+		return err
+	}
+	client, err := assistantremote.New(ref.Registry, "", insecure)
+	if err != nil {
+		return err
+	}
+
+	// Resolve to sha256
+	sha, err := GetDigest(ctx, client, ref)
+	if err != nil {
+		return err
+	}
+	resolvedUri := uri + "@" + sha.String()
+
+	// Pull
+	if err := PullComponent(ctx, resolvedUri, config, client); err != nil {
+		return err
+	}
+
+	// Edit daml.yaml / multi-package.yaml
+	if err := modifyYamlManifest(projectManifest, resolvedUri, index); err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully installed and added component %q to %q\n", resolvedUri, projectManifest)
+	return nil
 }
 
 func PullComponent(ctx context.Context, resolvedUri string, config *assistantconfig.Config, client *assistantremote.Remote) error {
@@ -122,27 +151,27 @@ func asSdkManifest(uri string) (*sdkmanifest.SdkManifest, error) {
 	}, nil
 }
 
-func getDamlYamlOrMultiPackageYaml() (string, error) {
+func getDamlYamlOrMultiPackageYaml() (string, string, error) {
 	p, ok, err := assistantconfig.GetDamlPackageAbsolutePath()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if ok {
-		return p, nil
+		return p, "", nil
 	}
 
 	p, ok, err = assistantconfig.GetMultiPackageAbsolutePath()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if ok {
-		return p, nil
+		return "", p, nil
 	}
 
-	return "", fmt.Errorf("not in a (single-package or multi-package) project directory")
+	return "", "", fmt.Errorf("not in a (single-package or multi-package) project directory")
 }
 
-func appendComponentToYaml(path, component string) error {
+func modifyYamlManifest(path, component string, index int) error {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return err
@@ -153,9 +182,37 @@ func appendComponentToYaml(path, component string) error {
 		return err
 	}
 
-	out, err := yamledit.AddToList(b, "components", string(item))
+	var out string
+	if index != -1 {
+		out, err = yamledit.ReplaceItemInList(b, "components", index, string(item))
+	} else {
+		out, err = yamledit.AddToList(b, "components", string(item))
+	}
 	if err != nil {
 		return err
 	}
+
 	return os.WriteFile(path, []byte(out), 0644)
+}
+
+func findExistingComponent(components componentlist.ComponentList, uri string) int {
+	for i, compEntry := range components {
+		comp := compEntry.StringBased
+		if comp == nil {
+			continue
+		}
+
+		// running 'dpm add' with the exact same uri as one in daml.yaml should behave like 'dpm update'.
+		// it will be a no-op, unless the cache has been cleared, in which case it will simply get re-downloaded
+		if *comp == uri {
+			return i
+		}
+
+		// running 'dpm add oci://blah/blah:<tag>' when daml.yaml has 'oci://blah/blah:<tag>@sha256'
+		// should update
+		if uri == dar.RemoveDigestFromUri(*comp) {
+			return i
+		}
+	}
+	return -1
 }

--- a/cmd/dpm/cmd/add/dar/dar.go
+++ b/cmd/dpm/cmd/add/dar/dar.go
@@ -87,7 +87,7 @@ func findExistingDependency(uri, depsFieldName string) (*damlpackage.ParsedDarDe
 
 		// running 'dpm add oci://blah/blah:<tag>' when daml.yaml has 'oci://blah/blah:<tag>@sha256'
 		// should update
-		if uri == removeDigestFromUri(dep.FullUrl.String()) {
+		if uri == RemoveDigestFromUri(dep.FullUrl.String()) {
 			return dep, nil
 		}
 	}
@@ -95,7 +95,8 @@ func findExistingDependency(uri, depsFieldName string) (*damlpackage.ParsedDarDe
 	return nil, nil
 }
 
-func removeDigestFromUri(uri string) string {
+// TODO move this to some proper package
+func RemoveDigestFromUri(uri string) string {
 	if i := strings.LastIndex(uri, "@sha256:"); i != -1 {
 		return uri[:i]
 	}

--- a/cmd/dpm/cmd/dpm_add_test.go
+++ b/cmd/dpm/cmd/dpm_add_test.go
@@ -134,3 +134,39 @@ data-dependencies:
 		require.Error(t, cmd.Execute())
 	})
 }
+
+// tests 'dpm add component' for a component that already exists in daml.yaml
+func (suite *MainSuite) TestAddingExistingComponent() {
+	t := suite.T()
+
+	t.Setenv(assistantconfig.DpmShaPinningEnabled, "true")
+
+	_, reg := testutil.StartRegistry(t)
+
+	newComponentWithoutRegistry := "newly/added"
+	newComponent := fmt.Sprintf("%s/%s", testutil.GetRemote(reg).Registry, newComponentWithoutRegistry)
+
+	// set up a daml.yaml containing a ":latest@sha256:" dar already
+	compRefLatest := newComponent + ":latest"
+	oldSha256 := "sha256:12d74505ebae3959746e8a2f5ab68b942a5580634dda7ea1a586874e07b52eb9"
+	projectDir := testutil.ActivateDamlYamlForTest(t, fmt.Sprintf(`
+components:
+  - pre-existing:1.2.3
+  - oci://%s@%s`, compRefLatest, oldSha256))
+
+	// push a new "latest" tag
+	args := testutil.PushComponentUri(reg, newComponentWithoutRegistry+":4.5.6", testutil.TestdataPath(t, "meepy-component", testutil.OS), "latest")
+	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
+
+	// Running 'dpm add oci://<uri>:latest' should now essentially bump to the new latest
+	cmd := createStdTestRootCmd(t, "add", "component", "oci://"+compRefLatest, "--insecure")
+	require.NoError(t, cmd.Execute())
+
+	damlPkg, err := damlpackage.Read(filepath.Join(projectDir, "daml.yaml"))
+	require.NoError(t, err)
+
+	assert.Len(t, damlPkg.ComponentsList, 2, "should not include more entries than it previously did")
+	assert.Equal(t, "pre-existing:1.2.3", *damlPkg.ComponentsList[0].StringBased)
+	assert.Contains(t, *damlPkg.ComponentsList[1].StringBased, "oci://"+compRefLatest+"@sha256:")
+	assert.NotContains(t, *damlPkg.ComponentsList[1].StringBased, oldSha256, "daml.yaml expected to not contain the old sha256 anymore")
+}


### PR DESCRIPTION
Running `dpm add compoenent oci://<uri>:latest`  should behave like `update` if that component already exists in the project.
 
```diff
diff --git a/daml.yaml b/daml.yaml
index 6a127af..f318018 100644
--- a/daml.yaml
+++ b/daml.yaml
@@ -1,4 +1,3 @@
-
 components:
   - pre-existing:1.2.3
-  - oci://127.0.0.1:57910/newly/added:latest@sha256:12d74505ebae3959746e8a2f5ab68b942a5580634dda7ea1a586874e07b52eb9
\ No newline at end of file
+  - oci://127.0.0.1:57910/newly/added:latest@sha256:0809353aea2c42b10ec28e6107df0e803d268ab32dd1cce82906f1c0d14e5de8