### PR TITLE
append sha256 to dars during 'dpm install'

### DIFF
--- a/cmd/dpm/cmd/add/dar/dar.go
+++ b/cmd/dpm/cmd/add/dar/dar.go
@@ -144,7 +144,7 @@ func AddOrUpdateDar(ctx context.Context, config *assistantconfig.Config, damlPac
 			Insecure: insecure,
 		},
 	}
-	if err := project.InstallDar(ctx, config, parsedDarDep); err != nil {
+	if _, err := project.InstallDar(ctx, config, parsedDarDep); err != nil {
 		return err
 	}
 

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -47,6 +47,8 @@ func (suite *MainSuite) TestResolutionOfOciDarDependencies() {
 
 	config := testutil.MkConfig(t)
 
+	projectDir := t.TempDir()
+	t.Chdir(projectDir)
 	require.NoError(t, utils.CopyFile(
 		testutil.TestdataPath(t, "oci-dar-deps", "daml.yaml"), // fixture daml.yaml
 		filepath.Join(projectDir, "daml.yaml"),

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -7,12 +7,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
+	"daml.com/x/assistant/pkg/assistantconfig/assistantremote"
+	"daml.com/x/assistant/pkg/damlpackage"
 	"daml.com/x/assistant/pkg/darmanifest"
+	"daml.com/x/assistant/pkg/ocilister"
 	"daml.com/x/assistant/pkg/resolution"
 	"daml.com/x/assistant/pkg/testutil"
+	"daml.com/x/assistant/pkg/utils"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,9 +43,15 @@ func (suite *MainSuite) TestResolutionOfOciDarDependencies() {
 	var res *resolution.Package
 
 	t := suite.T()
+	t.Setenv(assistantconfig.DpmShaPinningEnabled, "true")
 
 	config := testutil.MkConfig(t)
-	t.Chdir(testutil.TestdataPath(t, "oci-dar-deps")) // fixture daml.yaml
+
+	projectDir := t.TempDir()
+	utils.CopyFile(
+		testutil.TestdataPath(t, "oci-dar-deps", "daml.yaml"), // fixture daml.yaml
+		filepath.Join(projectDir, "daml.yaml"))
+	t.Chdir(projectDir)
 
 	// push dars to test registry
 	testutil.StartRegistry(t)
@@ -51,8 +62,8 @@ func (suite *MainSuite) TestResolutionOfOciDarDependencies() {
 	barDarRef, err := registry.ParseReference(fmt.Sprintf("%s/some/dars/n/stuff/bar:4.5.6", reg))
 	require.NoError(t, err)
 
-	pushDar(t, "oci://"+fooDarRef.String())
-	pushDar(t, "oci://"+barDarRef.String())
+	fooDarRefWithDigest := pushDar(t, "oci://"+fooDarRef.String())
+	barDarRefWithDigest := pushDar(t, "oci://"+barDarRef.String())
 
 	t.Run("dpm install package", func(t *testing.T) {
 		require.NoError(t, createStdTestRootCmd(t, "install", "package").Execute())
@@ -66,11 +77,11 @@ func (suite *MainSuite) TestResolutionOfOciDarDependencies() {
 	t.Run("resolution output should contain dars sourced via OCI", func(t *testing.T) {
 		assert.Contains(t,
 			res.GetResolvedDependencies(),
-			filepath.Join(config.CachePathForDar(&fooDarRef), "test.dar"),
+			filepath.Join(config.CachePathForDar(&fooDarRefWithDigest), "test.dar"),
 		)
 		assert.Contains(t,
 			res.GetResolvedDataDependencies(),
-			filepath.Join(config.CachePathForDar(&barDarRef), "test.dar"),
+			filepath.Join(config.CachePathForDar(&barDarRefWithDigest), "test.dar"),
 		)
 	})
 }
@@ -125,6 +136,7 @@ func checkDar(t *testing.T, darFile string) {
 
 func (suite *MainSuite) TestDarInstallWithArtifactLocationAlias() {
 	t := suite.T()
+	t.Setenv(assistantconfig.DpmShaPinningEnabled, "true")
 
 	config := testutil.MkConfig(t)
 
@@ -137,11 +149,11 @@ func (suite *MainSuite) TestDarInstallWithArtifactLocationAlias() {
 	barDarRef, err := registry.ParseReference(fmt.Sprintf("%s/some/dars/n/stuff/bar:4.5.6", reg))
 	require.NoError(t, err)
 
-	pushDar(t, "oci://"+fooDarRef.String())
-	pushDar(t, "oci://"+barDarRef.String())
+	fooDarRefWithDigest := pushDar(t, "oci://"+fooDarRef.String())
+	barDarRefWithDigest := pushDar(t, "oci://"+barDarRef.String())
 
 	// install dars
-	testutil.ActivateDamlYamlForTest(t, `
+	projectDir := testutil.ActivateDamlYamlForTest(t, `
 dependencies:
   - "@digital-asset/foo:1.2.3"
 
@@ -158,8 +170,10 @@ artifact-locations:
 `)
 	require.NoError(t, createStdTestRootCmd(t, "install", "package").Execute())
 
+	require.NotEmpty(t, projectDir)
+
 	t.Run("dar manifest includes main-package-id", func(t *testing.T) {
-		darManifestPath := filepath.Join(config.CachePathForDar(&fooDarRef), assistantconfig.DarManifestName)
+		darManifestPath := filepath.Join(config.CachePathForDar(&fooDarRefWithDigest), assistantconfig.DarManifestName)
 		m, err := darmanifest.ReadDarManifest(darManifestPath)
 		require.NoError(t, err)
 		assert.Equal(t, "0984ff5e3082add400bfcc6e3244bf9822ca5a617cfd92429e3fbce58058dbfa", m.Spec.Dars[0].MainPackageId)
@@ -167,12 +181,22 @@ artifact-locations:
 
 	// verify installed dars
 	t.Run("dars downloaded to the dpm cache", func(t *testing.T) {
-		assert.FileExists(t, filepath.Join(config.CachePathForDar(&fooDarRef), "test.dar"))
-		assert.FileExists(t, filepath.Join(config.CachePathForDar(&barDarRef), "test.dar"))
+		assert.FileExists(t, filepath.Join(config.CachePathForDar(&fooDarRefWithDigest), "test.dar"))
+		assert.FileExists(t, filepath.Join(config.CachePathForDar(&barDarRefWithDigest), "test.dar"))
+	})
+
+	t.Run("oci digest gets added to daml.yaml when missing", func(t *testing.T) {
+		damlPkg, err := damlpackage.Read(filepath.Join(projectDir, "daml.yaml"))
+		require.NoError(t, err)
+
+		assert.Len(t, damlPkg.Dependencies, 1, "should not include more entries than it previously did")
+		assert.Len(t, damlPkg.DataDependencies, 1, "should not include more entries than it previously did")
+		assert.Contains(t, *damlPkg.Dependencies[0].ValueOnly, "@sha256:")
+		assert.Contains(t, *damlPkg.DataDependencies[0].ValueOnly, "@sha256:")
 	})
 }
 
-func pushDar(t *testing.T, uri string, extraTags ...string) {
+func pushDar(t *testing.T, uri string, extraTags ...string) (refWithDigest registry.Reference) {
 	args := []string{
 		"publish", "dar", uri,
 		"-f", testutil.TestdataPath(t, "test-dar", "test.dar"),
@@ -189,4 +213,21 @@ func pushDar(t *testing.T, uri string, extraTags ...string) {
 
 	cmd := createStdTestRootCmd(t, args...)
 	require.NoError(t, cmd.Execute())
+
+	ref, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
+	require.NoError(t, err)
+
+	client, err := assistantremote.New(ref.Registry, "", true)
+	require.NoError(t, err)
+	descriptor, err := ocilister.FetchManifest(t.Context(), client, ref)
+	require.NoError(t, err)
+
+	return appendShaToRef(t, ref, descriptor.Digest.String())
+}
+
+func appendShaToRef(t *testing.T, ref registry.Reference, digest string) registry.Reference {
+	require.Contains(t, digest, "sha256:")
+	result, err := registry.ParseReference(ref.String() + "@" + digest)
+	require.NoError(t, err)
+	return result
 }

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -47,11 +47,10 @@ func (suite *MainSuite) TestResolutionOfOciDarDependencies() {
 
 	config := testutil.MkConfig(t)
 
-	projectDir := t.TempDir()
-	utils.CopyFile(
+	require.NoError(t, utils.CopyFile(
 		testutil.TestdataPath(t, "oci-dar-deps", "daml.yaml"), // fixture daml.yaml
-		filepath.Join(projectDir, "daml.yaml"))
-	t.Chdir(projectDir)
+		filepath.Join(projectDir, "daml.yaml"),
+	))
 
 	// push dars to test registry
 	testutil.StartRegistry(t)

--- a/cmd/dpm/cmd/install/package/package.go
+++ b/cmd/dpm/cmd/install/package/package.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -16,6 +17,7 @@ import (
 	"daml.com/x/assistant/pkg/ocilister"
 	"daml.com/x/assistant/pkg/ocipuller/remotepuller"
 	"daml.com/x/assistant/pkg/utils"
+	"daml.com/x/assistant/pkg/yamledit"
 	"github.com/samber/lo"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
@@ -110,45 +112,78 @@ func processDamlPackage(ctx context.Context, cmd *cobra.Command, config *assista
 		}
 	}
 
-	if err := installDars(ctx, config, lo.Values(damlPackage.ParsedDarDependencies.Dependencies)); err != nil {
+	yamlTarget := yamledit.YamlTarget{
+		YamlFilePath: damlPath,
+		FieldName:    "dependencies",
+	}
+	if err := installDars(ctx, config, lo.Values(damlPackage.ParsedDarDependencies.Dependencies), yamlTarget); err != nil {
 		return err
 	}
-	if err := installDars(ctx, config, lo.Values(damlPackage.ParsedDarDependencies.DataDependencies)); err != nil {
+
+	yamlTarget = yamledit.YamlTarget{
+		YamlFilePath: damlPath,
+		FieldName:    "data-dependencies",
+	}
+	if err := installDars(ctx, config, lo.Values(damlPackage.ParsedDarDependencies.DataDependencies), yamlTarget); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func installDars(ctx context.Context, config *assistantconfig.Config, dars []*damlpackage.ParsedDarDependency) error {
+func installDars(ctx context.Context, config *assistantconfig.Config, dars []*damlpackage.ParsedDarDependency, yamlTarget yamledit.YamlTarget) error {
 	for _, d := range dars {
-		if err := InstallDar(ctx, config, d); err != nil {
+		updatedDar, err := InstallDar(ctx, config, d)
+		if err != nil {
 			return err
+		}
+
+		// now update daml.yaml if we had to append a @sha256
+		if updatedDar != nil {
+			quotedUri := fmt.Sprintf("\"%s\"", updatedDar.StringWithAlias())
+			return yamledit.EditYaml(yamlTarget, quotedUri, updatedDar.Index)
 		}
 	}
 	return nil
 }
 
-func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpackage.ParsedDarDependency) error {
+func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpackage.ParsedDarDependency) (updatedDar *damlpackage.ParsedDarDependency, err error) {
 	if dar.FullUrl.Scheme != "oci" {
-		return nil
+		return nil, nil
 	}
 	fmt.Printf("installing dar %q...\n", dar.FullUrl.String())
 
 	client, ref, err := dar.GetOciRemote()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !assistantconfig.ShaPinningEnabled() && ocilister.IsFloaty(ref.Reference) {
-		return fmt.Errorf("tag not allowed in %q: only strict semver OCI tags are supported currently", dar.FullUrl.String())
+		return nil, fmt.Errorf("tag not allowed in %q: only strict semver OCI tags are supported currently", dar.FullUrl.String())
 	}
 
-	if assistantconfig.ShaPinningEnabled() {
-		if !strings.Contains(ref.Reference, "sha256:") {
-			// TODO support having `dpm install` resolve to sha256
-			// when the dar uri in daml.yaml doesn't already include it
-			return fmt.Errorf("currently 'dpm install' requires dar oci URIs in daml.yaml to include '@sha256'. Prefer 'dpm add dar' command to add dars to your daml.yaml")
+	// if the URI doesn't already have a sha256, give it one.
+	// (this does not mean we're gonna bump dependencies)
+	if !strings.Contains(dar.FullUrl.String(), "@sha256:") {
+		ociManifest, err := ocilister.FetchManifest(ctx, client, *ref)
+		if err != nil {
+			return nil, err
+		}
+
+		newUrl, err := url.Parse(dar.FullUrl.String() + "@" + ociManifest.Digest.String())
+		if err != nil {
+			return nil, err
+		}
+		updatedDar = &damlpackage.ParsedDarDependency{
+			FullUrl:       newUrl,
+			Location:      dar.Location,
+			MainPackageId: dar.MainPackageId,
+			Index:         dar.Index,
+		}
+
+		client, ref, err = updatedDar.GetOciRemote()
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -157,14 +192,17 @@ func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpa
 
 	ok, err := utils.DirExists(darDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if ok {
 		fmt.Println("Dar already installed.")
-		return nil
+		return nil, nil
 	}
-	_, err = puller.PullDarByFullPath(ctx, ref.Repository, ref.Reference, darDir)
-	return err
+	if _, err = puller.PullDarByFullPath(ctx, ref.Repository, ref.Reference, darDir); err != nil {
+		return nil, err
+	}
+
+	return updatedDar, nil
 }
 
 func installOverrides(ctx context.Context, cmd *cobra.Command, config *assistantconfig.Config, absPath string, sub bool) error {

--- a/cmd/dpm/cmd/install/package/package.go
+++ b/cmd/dpm/cmd/install/package/package.go
@@ -163,6 +163,7 @@ func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpa
 	}
 
 	if assistantconfig.ShaPinningEnabled() && !strings.Contains(dar.FullUrl.String(), "@sha256:") {
+		ociManifest, err := ocilister.FetchManifest(ctx, client, *ref)
 		if err != nil {
 			return nil, err
 		}
@@ -193,7 +194,7 @@ func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpa
 	}
 	if ok {
 		fmt.Println("Dar already installed.")
-		return nil, nil
+		return updatedDar, nil
 	}
 	if _, err = puller.PullDarByFullPath(ctx, ref.Repository, ref.Reference, darDir); err != nil {
 		return nil, err

--- a/cmd/dpm/cmd/install/package/package.go
+++ b/cmd/dpm/cmd/install/package/package.go
@@ -162,10 +162,7 @@ func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpa
 		return nil, fmt.Errorf("tag not allowed in %q: only strict semver OCI tags are supported currently", dar.FullUrl.String())
 	}
 
-	// if the URI doesn't already have a sha256, give it one.
-	// (this does not mean we're gonna bump dependencies)
-	if !strings.Contains(dar.FullUrl.String(), "@sha256:") {
-		ociManifest, err := ocilister.FetchManifest(ctx, client, *ref)
+	if assistantconfig.ShaPinningEnabled() && !strings.Contains(dar.FullUrl.String(), "@sha256:") {
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/dpm/cmd/install_package_test.go
+++ b/cmd/dpm/cmd/install_package_test.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"context"
-	"daml.com/x/assistant/pkg/ociindex"
+
 	"fmt"
 	"io"
 	"net/http/httptest"
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"daml.com/x/assistant/pkg/ociindex"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/resolution"

--- a/pkg/damlpackage/damlproject.go
+++ b/pkg/damlpackage/damlproject.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"strings"
 
 	"daml.com/x/assistant/pkg/componentlist"
 	"daml.com/x/assistant/pkg/sdkmanifest"
@@ -78,6 +79,15 @@ func ReadFromContents(contents []byte, absoluteFilePath string) (*DamlPackage, e
 
 		// zero it out to make sure we really aren't relying on it past this point
 		obj.DeprecatedOverrideComponents = nil
+	}
+
+	// populate the in-memory Alias field for artifact-locations
+	// TODO this should really happen during unmarshalling of that field
+	for alias, artifactLoc := range obj.ArtifactLocations {
+		if !strings.HasPrefix(alias, "@") {
+			return nil, fmt.Errorf("artifact-location alias %q is invalid. Must begin with '@'", alias)
+		}
+		artifactLoc.Alias = alias
 	}
 
 	obj.ParsedDarDependencies = &ParsedDarDependencies{}

--- a/pkg/damlpackage/locations.go
+++ b/pkg/damlpackage/locations.go
@@ -17,6 +17,7 @@ import (
 type ArtifactLocations map[string]*ArtifactLocation
 
 type ArtifactLocation struct {
+	Alias    string `yaml:"-"`
 	Url      string `yaml:"url"`
 	Auth     string `yaml:"auth"`
 	Insecure bool   `yaml:"insecure"`
@@ -37,6 +38,20 @@ type ParsedDarDependency struct {
 	// the index of this dependency in the list in daml.yaml.
 	// useful when trying to update the dep as part of `dpm update`.
 	Index int
+}
+
+// StringWithAlias will reconstruct the original '@<alias>/<rest of uri>' for oci-based dars
+func (d *ParsedDarDependency) StringWithAlias() string {
+	if d.FullUrl == nil {
+		return ""
+	}
+	u := d.FullUrl.String()
+
+	if d.Location == nil {
+		return u
+	}
+
+	return d.Location.Alias + strings.TrimPrefix(u, d.Location.Url)
 }
 
 func (d *ParsedDarDependency) GetOciRemote() (*assistantremote.Remote, *registry.Reference, error) {

--- a/pkg/damlpackage/locations.go
+++ b/pkg/damlpackage/locations.go
@@ -47,7 +47,7 @@ func (d *ParsedDarDependency) StringWithAlias() string {
 	}
 	u := d.FullUrl.String()
 
-	if d.Location == nil {
+	if d.Location == nil || !strings.HasPrefix(u, d.Location.Url) {
 		return u
 	}
 

--- a/pkg/yamledit/yamledit.go
+++ b/pkg/yamledit/yamledit.go
@@ -3,11 +3,38 @@ package yamledit
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/parser"
 )
+
+type YamlTarget struct {
+	YamlFilePath string
+	FieldName    string
+}
+
+// EditYaml adds an item to list in yaml file
+// or replace the given index with it
+func EditYaml(info YamlTarget, item string, index int) error {
+	b, err := os.ReadFile(info.YamlFilePath)
+	if err != nil {
+		return err
+	}
+
+	var out string
+	if index != -1 {
+		out, err = ReplaceItemInList(b, info.FieldName, index, item)
+	} else {
+		out, err = AddToList(b, info.FieldName, item)
+	}
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(info.YamlFilePath, []byte(out), 0644)
+}
 
 // AddToList adds item to the given target field.
 // item can be a simple value or a whole object


### PR DESCRIPTION
-  when running `dpm install`, modify `daml.yaml` and append `@sha256:`  if it contains dar URIs that don't have `@sha256` already
- this works with artifact-locations `@alias` as well
