### PR TITLE
:turtle: components sha-pinning + caching

### DIFF
--- a/cmd/dpm/cmd/add/component/component.go
+++ b/cmd/dpm/cmd/add/component/component.go
@@ -139,7 +139,7 @@ func asSdkManifest(uri string) (*sdkmanifest.SdkManifest, error) {
 		&componentlist.ComponentEntry{
 			StringBased: &uri,
 		},
-	}.ToMap()
+	}.ToMap(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/dpm/cmd/add/dar/dar.go
+++ b/cmd/dpm/cmd/add/dar/dar.go
@@ -127,11 +127,11 @@ func AddOrUpdateDar(ctx context.Context, config *assistantconfig.Config, damlPac
 	}
 
 	// Resolve to sha256
-	ociManifest, err := ocilister.FetchManifest(ctx, client, ref)
+	resolvedDigest, _, err := ocilister.FetchManifest(ctx, client, ref)
 	if err != nil {
 		return err
 	}
-	resolvedUri := uri + "@" + ociManifest.Digest.String()
+	resolvedUri := uri + "@" + resolvedDigest.String()
 
 	// Pull
 	parsedUrl, err := url.Parse(resolvedUri)

--- a/cmd/dpm/cmd/assistant_test.go
+++ b/cmd/dpm/cmd/assistant_test.go
@@ -638,12 +638,7 @@ func (suite *MainSuite) TestComponentSubdirFilesPerm() {
 
 	c, err := assistantconfig.Get()
 	require.NoError(t, err)
-
-	sha, err := testutil.FindManifestByAnnotation(c.CachePath, "meep", "1.2.3")
-	require.NoError(t, err)
-
-	s, err := os.Stat(filepath.Join(c.CachePath, "components", "meep", strings.ReplaceAll(sha, ":", "_"), "just-a-dir", "xyz"))
-	require.NoError(t, err)
+	s, err := os.Stat(filepath.Join(c.CachePath, "components", "meep", "1.2.3", "just-a-dir", "xyz"))
 
 	assert.Equal(t, mode, s.Mode())
 }

--- a/cmd/dpm/cmd/dars_test.go
+++ b/cmd/dpm/cmd/dars_test.go
@@ -220,10 +220,10 @@ func pushDar(t *testing.T, uri string, extraTags ...string) (refWithDigest regis
 
 	client, err := assistantremote.New(ref.Registry, "", true)
 	require.NoError(t, err)
-	descriptor, err := ocilister.FetchManifest(t.Context(), client, ref)
+	resolvedDigest, _, err := ocilister.FetchManifest(t.Context(), client, ref)
 	require.NoError(t, err)
 
-	return appendShaToRef(t, ref, descriptor.Digest.String())
+	return appendShaToRef(t, ref, resolvedDigest.String())
 }
 
 func appendShaToRef(t *testing.T, ref registry.Reference, digest string) registry.Reference {

--- a/cmd/dpm/cmd/install/package/package.go
+++ b/cmd/dpm/cmd/install/package/package.go
@@ -141,7 +141,8 @@ func installDars(ctx context.Context, config *assistantconfig.Config, dars []*da
 		// now update daml.yaml if we had to append a @sha256
 		if updatedDar != nil {
 			quotedUri := fmt.Sprintf("\"%s\"", updatedDar.StringWithAlias())
-			return yamledit.EditYaml(yamlTarget, quotedUri, updatedDar.Index)
+			yamlTarget.Index = updatedDar.Index
+			return yamledit.EditYaml(yamlTarget, quotedUri)
 		}
 	}
 	return nil
@@ -163,12 +164,12 @@ func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpa
 	}
 
 	if assistantconfig.ShaPinningEnabled() && !strings.Contains(dar.FullUrl.String(), "@sha256:") {
-		ociManifest, err := ocilister.FetchManifest(ctx, client, *ref)
+		resolvedDigest, _, err := ocilister.FetchManifest(ctx, client, *ref)
 		if err != nil {
 			return nil, err
 		}
 
-		newUrl, err := url.Parse(dar.FullUrl.String() + "@" + ociManifest.Digest.String())
+		newUrl, err := url.Parse(dar.FullUrl.String() + "@" + resolvedDigest.String())
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/dpm/cmd/install/package/package.go
+++ b/cmd/dpm/cmd/install/package/package.go
@@ -64,7 +64,7 @@ func InstallPackage(config *assistantconfig.Config, cmd *cobra.Command) error {
 			}
 		}
 
-		if err := installOverrides(ctx, cmd, config, multiPackagePath, false); err != nil {
+		if err := installMultiPackageYamlComponentsOnly(ctx, cmd, config); err != nil {
 			return err
 		}
 		pkgs := multiDamlPackage.AbsolutePackages()
@@ -75,7 +75,7 @@ func InstallPackage(config *assistantconfig.Config, cmd *cobra.Command) error {
 			if err := processDamlPackage(ctx, cmd, modifiedConfig, damlPackagePath); err != nil {
 				return err
 			}
-			if err := installOverrides(ctx, cmd, config, damlPackagePath, true); err != nil {
+			if err := installOverridesForPackage(ctx, cmd, config, damlPackagePath); err != nil {
 				return err
 			}
 		}
@@ -91,7 +91,7 @@ func InstallPackage(config *assistantconfig.Config, cmd *cobra.Command) error {
 		if err := processDamlPackage(ctx, cmd, modifiedConfig, damlPackagePath); err != nil {
 			return err
 		}
-		return installOverrides(ctx, cmd, config, damlPackagePath, false)
+		return installOverridesForPackage(ctx, cmd, config, damlPackagePath)
 	}
 
 	return nil
@@ -204,7 +204,28 @@ func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpa
 	return updatedDar, nil
 }
 
-func installOverrides(ctx context.Context, cmd *cobra.Command, config *assistantconfig.Config, absPath string, sub bool) error {
+func installMultiPackageYamlComponentsOnly(ctx context.Context, cmd *cobra.Command, config *assistantconfig.Config) error {
+	puller, err := remotepuller.NewFromRemoteConfig(config)
+	if err != nil {
+		return err
+	}
+	a := assembler.New(config, puller)
+	assemblyPlan, err := assemblyplan.New(ctx, config, a)
+	if err != nil {
+		return err
+	}
+	assemblyPlan.DamlPackage = nil
+	if !assemblyPlan.HasOverrides() {
+		return nil
+	}
+	cmd.Println("Installing multi-package.yaml components...")
+	return utils.WithInstallLock(ctx, config.InstallLocalFilePath, func() error {
+		_, err := assemblyPlan.Assemble(ctx)
+		return err
+	})
+}
+
+func installOverridesForPackage(ctx context.Context, cmd *cobra.Command, config *assistantconfig.Config, absPath string) error {
 	puller, err := remotepuller.NewFromRemoteConfig(config)
 	if err != nil {
 		return err
@@ -214,9 +235,7 @@ func installOverrides(ctx context.Context, cmd *cobra.Command, config *assistant
 	if err != nil {
 		return err
 	}
-	if sub {
-		assemblyPlan.MultiPackage = nil
-	}
+	assemblyPlan.MultiPackage = nil
 	if !assemblyPlan.HasOverrides() {
 		cmd.Println("No opt-in components to install")
 		return nil

--- a/cmd/dpm/cmd/install_package_test.go
+++ b/cmd/dpm/cmd/install_package_test.go
@@ -12,12 +12,15 @@ import (
 	"testing"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
+	"daml.com/x/assistant/pkg/assistantconfig/assistantremote"
+	"daml.com/x/assistant/pkg/ocilister"
 	"daml.com/x/assistant/pkg/resolution"
 	"daml.com/x/assistant/pkg/testutil"
 	"daml.com/x/assistant/pkg/utils"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/registry"
 )
 
 func (suite *MainSuite) TestInstallPackage() {
@@ -161,6 +164,93 @@ func testInstallPackage(t *testing.T, installCommand []string) {
 			require.NoError(t, createStdTestRootCmd(t, "meep").Execute())
 			checkComponent(regURL+"/"+"foo/bar/meep", "1.2.3")
 		})
+	})
+}
+
+func (suite *MainSuite) TestShaPinningForUriComponentsInSinglePackageProject() {
+	t := suite.T()
+
+	t.Setenv(assistantconfig.DpmShaPinningEnabled, "true")
+
+	_ = testutil.MkConfig(t)
+	_, reg := testutil.StartRegistry(t)
+	newComponentRepo := "newly/added:4.5.6"
+	newComponent := fmt.Sprintf("oci://%s/%s", testutil.GetRemote(reg).Registry, newComponentRepo)
+
+	args := testutil.PushComponentUri(reg, newComponentRepo, testutil.TestdataPath(t, "meepy-component", testutil.OS))
+	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
+
+	projectDir := testutil.ActivateDamlYamlForTest(t, fmt.Sprintf(`
+components:
+  - %s
+`, newComponent))
+
+	t.Run("dpm install appends missing sha256 to oci uri", func(t *testing.T) {
+		cmd := createStdTestRootCmd(t, "install")
+		require.NoError(t, cmd.Execute())
+
+		ref, err := registry.ParseReference(strings.TrimPrefix(newComponent, "oci://"))
+		require.NoError(t, err)
+		client, err := assistantremote.New(ref.Registry, "", true)
+		require.NoError(t, err)
+		resolvedDigest, _, err := ocilister.FetchManifest(t.Context(), client, ref)
+		require.NoError(t, err)
+
+		newContent, err := os.ReadFile(filepath.Join(projectDir, "daml.yaml"))
+		require.NoError(t, err)
+		assert.Contains(t, string(newContent), newComponent+"@"+resolvedDigest.String())
+	})
+
+	t.Run("dpm resolve works for sha256 pinned oci components", func(t *testing.T) {
+		resolution := runResolveCommand(t)
+		comps := lo.Values(lo.Values(resolution.Packages)[0].ComponentsV2)
+		assert.Len(t, comps, 1)
+		assert.Equal(t, "4.5.6", comps[0]["version"])
+	})
+
+	t.Run("dpm installing more than once", func(t *testing.T) {
+		cmd := createStdTestRootCmd(t, "install")
+		require.NoError(t, cmd.Execute())
+	})
+}
+
+func (suite *MainSuite) TestShaPinningForUriComponentsInMultiPackageProject() {
+	t := suite.T()
+
+	t.Setenv(assistantconfig.DpmShaPinningEnabled, "true")
+
+	_ = testutil.MkConfig(t)
+	_, reg := testutil.StartRegistry(t)
+	newComponentRepo := "newly/added:4.5.6"
+	newComponent := fmt.Sprintf("oci://%s/%s", testutil.GetRemote(reg).Registry, newComponentRepo)
+
+	args := testutil.PushComponentUri(reg, newComponentRepo, testutil.TestdataPath(t, "meepy-component", testutil.OS))
+	require.NoError(t, createStdTestRootCmd(t, args...).Execute())
+
+	projectDir := testutil.ActivateMultiPackageYamlForTest(t, fmt.Sprintf(`
+components:
+  - %s
+`, newComponent))
+
+	t.Run("dpm install appends missing sha256 to oci uri", func(t *testing.T) {
+		cmd := createStdTestRootCmd(t, "install", "package")
+		require.NoError(t, cmd.Execute())
+
+		ref, err := registry.ParseReference(strings.TrimPrefix(newComponent, "oci://"))
+		require.NoError(t, err)
+		client, err := assistantremote.New(ref.Registry, "", true)
+		require.NoError(t, err)
+		resolvedDigest, _, err := ocilister.FetchManifest(t.Context(), client, ref)
+		require.NoError(t, err)
+
+		newContent, err := os.ReadFile(filepath.Join(projectDir, "multi-package.yaml"))
+		require.NoError(t, err)
+		assert.Contains(t, string(newContent), newComponent+"@"+resolvedDigest.String())
+	})
+
+	t.Run("dpm installing more than once", func(t *testing.T) {
+		cmd := createStdTestRootCmd(t, "install")
+		require.NoError(t, cmd.Execute())
 	})
 }
 

--- a/cmd/dpm/cmd/install_package_test.go
+++ b/cmd/dpm/cmd/install_package_test.go
@@ -134,16 +134,9 @@ func testInstallPackage(t *testing.T, installCommand []string) {
 		randoSHA := randoDescriptor.Digest.String()
 		t.Setenv("TEST_RANDO_SHA", randoSHA)
 
-		repoJava, err := client.Repo("components/javabro")
-		require.NoError(t, err)
-		javaDescriptor, err := repoJava.Resolve(ctx, "6.7.8")
-		require.NoError(t, err)
-		javaSHA := javaDescriptor.Digest.String()
-		t.Setenv("TEST_JAVA_SHA", javaSHA)
-
 		cmd := createStdTestRootCmd(t, installCommand...)
-
 		require.NoError(t, cmd.Execute())
+
 		require.NoError(t, createStdTestRootCmd(t, "meep").Execute())
 
 		deepResolution := runResolveCommand(t)
@@ -159,8 +152,6 @@ func testInstallPackage(t *testing.T, installCommand []string) {
 
 		// Test that the cache and dpm resolve use the full URsI for `oci://` based components
 		checkComponent(regURL+"/"+"foo/bar/meep", strings.ReplaceAll(meepSHA, ":", "_"))
-		// and use the shorthand for non `oci://` components
-		checkComponent("javabro", strings.ReplaceAll(javaSHA, ":", "_"))
 
 		t.Run("test that moving tag to new sha doesn't break pinning", func(t *testing.T) {
 			args := testutil.PushComponentUri(reg, fmt.Sprintf("%s/%s:%s", "foo/bar", "meep", "1.2.3"), testutil.TestdataPath(t, "components", "rando"))

--- a/cmd/dpm/cmd/install_package_test.go
+++ b/cmd/dpm/cmd/install_package_test.go
@@ -165,6 +165,21 @@ func testInstallPackage(t *testing.T, installCommand []string) {
 			checkComponent(regURL+"/"+"foo/bar/meep", "1.2.3")
 		})
 	})
+
+	t.Run("install package with local-filepath components", func(t *testing.T) {
+		localComponentPath := testutil.TestdataPath(t, "another-generic-component")
+
+		testutil.ActivateDamlYamlForTest(t, fmt.Sprintf(`
+components:
+    - name: my-local-component
+      path: %s`, localComponentPath))
+
+		cmd := createStdTestRootCmd(t, installCommand...)
+		require.NoError(t, cmd.Execute())
+
+		deepResolution := runResolveCommand(t)
+		assert.Equal(t, localComponentPath, lo.Values(deepResolution.Packages)[0].ComponentsV2["my-local-component"]["path"])
+	})
 }
 
 func (suite *MainSuite) TestShaPinningForUriComponentsInSinglePackageProject() {

--- a/cmd/dpm/cmd/install_package_test.go
+++ b/cmd/dpm/cmd/install_package_test.go
@@ -71,7 +71,14 @@ func testInstallPackage(t *testing.T, installCommand []string) {
 		regURL, altURL := setupRegistriesAndPublishedComponents(t)
 
 		// run install package
-		require.NoError(t, os.Chdir(testutil.TestdataPath(t, "multi-registry", testutil.OS)))
+
+		tmpProjectDir := t.TempDir()
+		require.NoError(t, utils.CopyFile(
+			filepath.Join(testutil.TestdataPath(t, "multi-registry", "daml.yaml")),
+			filepath.Join(tmpProjectDir, "daml.yaml"),
+		))
+		t.Chdir(tmpProjectDir)
+
 		cmd := createStdTestRootCmd(t, installCommand...)
 		require.NoError(t, cmd.Execute())
 
@@ -81,20 +88,14 @@ func testInstallPackage(t *testing.T, installCommand []string) {
 		// run resolve command
 		deepResolution := runResolveCommand(t)
 		assert.Len(t, deepResolution.Packages, 1)
-		assert.Len(t, lo.Values(deepResolution.Packages)[0].Components, 4)
+		assert.Len(t, lo.Values(deepResolution.Packages)[0].Components, 3)
 
 		checkComponent := checkComponent(t, deepResolution, dpmHome)
-		meepSHA, err := testutil.FindManifestByAnnotation(filepath.Join(dpmHome, "cache"), "meep", "1.2.3")
-		require.NoError(t, err)
-		randoSHA, err := testutil.FindManifestByAnnotation(filepath.Join(dpmHome, "cache"), "rando", "1.2.4")
 		require.NoError(t, err)
 
 		// Test that the cache and dpm resolve use the full URI for `oci://` based components
-		checkComponent(regURL+"/"+"foo/bar/meep", strings.ReplaceAll(meepSHA, ":", "_"))
-		checkComponent(altURL+"/"+"bar/foo/rando", strings.ReplaceAll(randoSHA, ":", "_"))
-
-		// local non `oci://` components
-		assert.Equal(t, testutil.TestdataPath(t, "another-generic-component"), lo.Values(deepResolution.Packages)[0].ComponentsV2["my-local-component"]["path"])
+		checkComponent(regURL+"/"+"foo/bar/meep", "1.2.3")
+		checkComponent(altURL+"/"+"bar/foo/rando", "1.2.4")
 	})
 
 	t.Run("install package with pinning", func(t *testing.T) {

--- a/cmd/dpm/cmd/install_package_test.go
+++ b/cmd/dpm/cmd/install_package_test.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"daml.com/x/assistant/pkg/ociindex"
-
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/resolution"
 	"daml.com/x/assistant/pkg/testutil"
@@ -166,54 +164,37 @@ func testInstallPackage(t *testing.T, installCommand []string) {
 	})
 }
 
-func (suite *MainSuite) TestLegacyCacheResolution() {
+func (suite *MainSuite) TestLegacyCacheResolutionForSdkComponentsUnaffectedByShaCaching() {
 	t := suite.T()
-
-	cwd, err := os.Getwd()
-
-	require.NoError(t, err)
-
-	t.Cleanup(func() { require.NoError(t, os.Chdir(cwd)) })
 
 	installSdk(t, []string{someSdkVersion})
 
-	c, err := assistantconfig.Get()
-	require.NoError(t, err)
+	deepResolution := runResolveCommand(t)
+	comp := deepResolution.DefaultSDK[someSdkVersion].ComponentsV2["meep"]
+	assert.Equal(t, "1.2.3", comp["version"])
+	assert.Equal(t,
+		filepath.Join(os.Getenv(assistantconfig.DpmHomeEnvVar), "cache", "components", "meep", "1.2.3"),
+		comp["path"])
+}
 
-	require.NoError(t, os.Chdir(testutil.TestdataPath(t, "resolve-test", testutil.OS)))
+func (suite *MainSuite) TestLegacyCacheResolutionForShorthandComponentsUnaffectedByShaCaching() {
+	t := suite.T()
+	c := testutil.MkConfig(t)
+
+	ctx := testutil.Context(t)
+	_, reg := testutil.StartRegistry(t)
+
+	// Want to ensure that version is still using handleOCI - push up using internal DA pushComponent
+	testutil.PushComponent(t, ctx, reg, "meep", "1.2.3", testutil.TestdataPath(t, "meepy-component", testutil.OS))
+
+	t.Chdir(testutil.TestdataPath(t, "resolve-test", testutil.OS))
+	cmd := createStdTestRootCmd(t, "install", "package")
+	require.NoError(t, cmd.Execute())
 
 	deepResolution := runResolveCommand(t)
 	comp := lo.Values(deepResolution.Packages)[0].ComponentsV2["meep"]
-	assert.Len(t, deepResolution.Packages, 1)
+	assert.Equal(t, comp["path"], filepath.Join(c.CachePath, "components", "meep", "1.2.3"))
 	assert.Equal(t, "1.2.3", comp["version"])
-
-	t.Run("test cache still writing to version", func(t *testing.T) {
-		ctx := testutil.Context(t)
-		client, reg := testutil.StartRegistry(t)
-
-		// Want to ensure that version is still using handleOCI - push up using internal DA pushComponent
-		testutil.PushComponent(t, ctx, reg, "meep", "1.2.3", testutil.TestdataPath(t, "meepy-component", testutil.OS))
-		require.NoError(t, os.Chdir(testutil.TestdataPath(t, "resolve-test", testutil.OS)))
-
-		cmd := createStdTestRootCmd(t, "install", "package")
-		require.NoError(t, cmd.Execute())
-
-		repoMeep, err := client.Repo("components/meep")
-		require.NoError(t, err)
-		meepDescriptor, err := repoMeep.Resolve(ctx, "1.2.3")
-		require.NoError(t, err)
-
-		rc, err := repoMeep.Fetch(ctx, meepDescriptor)
-		require.NoError(t, err)
-		defer rc.Close()
-
-		index, _, err := ociindex.FetchIndex(ctx, client, "components/meep", "1.2.3")
-		require.NoError(t, err)
-
-		comp := lo.Values(deepResolution.Packages)[0].ComponentsV2["meep"]
-		assert.Equal(t, comp["path"], filepath.Join(c.CachePath, "components", utils.UrlToFilePath("meep"), strings.ReplaceAll(index.Manifests[0].Digest.String(), ":", "_")))
-		assert.Equal(t, "1.2.3", comp["version"])
-	})
 }
 
 func checkComponent(t *testing.T, deepResolution *resolution.Resolution, dpmHome string) func(name string, version string) {

--- a/cmd/dpm/cmd/install_package_test.go
+++ b/cmd/dpm/cmd/install_package_test.go
@@ -141,7 +141,7 @@ func testInstallPackage(t *testing.T, installCommand []string) {
 
 		deepResolution := runResolveCommand(t)
 		assert.Len(t, deepResolution.Packages, 1)
-		assert.Len(t, lo.Values(deepResolution.Packages)[0].Components, 3)
+		assert.Len(t, lo.Values(deepResolution.Packages)[0].Components, 2)
 
 		checkComponent := func(name, version string) {
 			// Test that the cache and dpm resolve use the full URI for `oci://` based components
@@ -151,7 +151,7 @@ func testInstallPackage(t *testing.T, installCommand []string) {
 		}
 
 		// Test that the cache and dpm resolve use the full URsI for `oci://` based components
-		checkComponent(regURL+"/"+"foo/bar/meep", strings.ReplaceAll(meepSHA, ":", "_"))
+		checkComponent(regURL+"/"+"foo/bar/meep", "1.2.3")
 
 		t.Run("test that moving tag to new sha doesn't break pinning", func(t *testing.T) {
 			args := testutil.PushComponentUri(reg, fmt.Sprintf("%s/%s:%s", "foo/bar", "meep", "1.2.3"), testutil.TestdataPath(t, "components", "rando"))
@@ -160,7 +160,7 @@ func testInstallPackage(t *testing.T, installCommand []string) {
 			require.NoError(t, cmd.Execute())
 			// assert meep component not overwritten
 			require.NoError(t, createStdTestRootCmd(t, "meep").Execute())
-			checkComponent(regURL+"/"+"foo/bar/meep", strings.ReplaceAll(meepSHA, ":", "_"))
+			checkComponent(regURL+"/"+"foo/bar/meep", "1.2.3")
 		})
 	})
 }

--- a/cmd/dpm/cmd/repo_test.go
+++ b/cmd/dpm/cmd/repo_test.go
@@ -104,10 +104,7 @@ func (suite *RepoSuite) TestRepoCreateTarball() {
 			verifyLnkAtPath(t, filepath.Join(dir, entries[0].Name()))
 		})
 		t.Run("verify LICENSE file", func(t *testing.T) {
-			sha, err := testutil.FindManifestByAnnotation(filepath.Join(tmpDamlHome, "cache"), "dpm", "4.5.6")
-			require.NoError(t, err)
-
-			licenseFile := filepath.Join(tmpDamlHome, "cache", "components", "dpm", strings.ReplaceAll(sha, ":", "_"), "LICENSE")
+			licenseFile := filepath.Join(tmpDamlHome, "cache", "components", "dpm", "4.5.6", "LICENSE")
 			bytes, err := os.ReadFile(licenseFile)
 			require.NoError(t, err)
 			assert.Equal(t, bytes, root.License)

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -5,13 +5,8 @@ package assembler
 
 import (
 	"context"
-	ociconsts "daml.com/x/assistant/pkg/oci"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Masterminds/semver/v3"
-	"github.com/opencontainers/go-digest"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"log/slog"
 	"maps"
 	"os"
@@ -22,13 +17,15 @@ import (
 	"daml.com/x/assistant/pkg/assistantconfig/assistantremote"
 	"daml.com/x/assistant/pkg/builtincommand"
 	"daml.com/x/assistant/pkg/component"
+	"daml.com/x/assistant/pkg/ocilister"
 	"daml.com/x/assistant/pkg/ocipuller"
 	"daml.com/x/assistant/pkg/ocipuller/remotepuller"
 	"daml.com/x/assistant/pkg/resolution"
 	"daml.com/x/assistant/pkg/sdkmanifest"
 	"daml.com/x/assistant/pkg/simpleplatform"
 	"daml.com/x/assistant/pkg/utils"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"daml.com/x/assistant/pkg/yamledit"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/samber/lo"
 	"oras.land/oras-go/v2/registry"
 )
@@ -270,7 +267,7 @@ func (a *Assembler) collectAssistant(ctx context.Context, assistant *sdkmanifest
 	if assistant.LocalPath != nil {
 		return "", fmt.Errorf("assistant can only be OCI and not a local-path")
 	}
-	p, err := a.HandleOCI(ctx, assistant)
+	p, err := a.handleOCI(ctx, assistant)
 	if err != nil {
 		return "", err
 	}
@@ -329,12 +326,12 @@ func (a *Assembler) collectComponent(ctx context.Context, basePath string, comp 
 	if comp.LocalPath != nil {
 		p = a.handleLocalDir(filepath.Dir(basePath), *comp.LocalPath)
 	} else if comp.Uri != nil {
-		p, err = a.HandleURI(ctx, comp)
+		p, err = a.handleURI(ctx, comp)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		p, err = a.HandleOCI(ctx, comp)
+		p, err = a.handleOCI(ctx, comp)
 		if err != nil {
 			return nil, err
 		}
@@ -350,13 +347,7 @@ func (a *Assembler) collectComponent(ctx context.Context, basePath string, comp 
 		return nil, err
 	}
 
-	// either resolve or use base
-	var version string
-	if comp.Version != nil {
-		version = comp.Version.Value().String()
-	} else {
-		version = filepath.Base(absPath)
-	}
+	version := filepath.Base(absPath)
 
 	return &ResolvedComponent{
 		Component:     parsedComp,
@@ -370,36 +361,114 @@ func (a *Assembler) handleLocalDir(basePath, componentPath string) string {
 	return utils.ResolvePath(basePath, componentPath)
 }
 
-func (a *Assembler) HandleURI(ctx context.Context, comp *sdkmanifest.Component) (string, error) {
-	prefixTrimmedOCI := strings.TrimPrefix(*comp.Uri, "oci://")
-	ref, err := registry.ParseReference(prefixTrimmedOCI)
+func (a *Assembler) handleURI(ctx context.Context, comp *sdkmanifest.Component) (string, error) {
+	uri := *comp.Uri
+
+	ref, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
 	if err != nil {
 		return "", err
 	}
 
-	if err := registry.Reference.ValidateReferenceAsTag(ref); err == nil {
-		uriDigest, found, err := a.FindManifestByAnnotation(filepath.Base(comp.Name), ref.Reference)
+	if a.config.AutoInstall {
+		var version string
+
+		client, err := assistantremote.New(ref.Registry, a.config.RegistryAuthPath, a.config.Insecure)
 		if err != nil {
 			return "", err
 		}
-		if found {
-			ref.Reference = uriDigest
-			return a.handleURI(ctx, ref, comp)
+
+		var newUri string
+
+		sha256Digest, digestErr := ref.Digest()
+
+		// if the URI doesn't already have a sha256, give it one.
+		// (this does not necessarily mean we're gonna bump dependencies)
+		if digestErr != nil {
+			resolvedDigest, ociManifest, err := ocilister.FetchManifest(ctx, client, ref)
+			if err != nil {
+				return "", err
+			}
+			sha256Digest = resolvedDigest
+			version = ociManifest.Annotations[v1.AnnotationVersion]
+			newUri = uri + "@" + resolvedDigest.String()
+
+			// update client and ref
+			ref, err = registry.ParseReference(strings.TrimPrefix(newUri, "oci://"))
+			if err != nil {
+				return "", err
+			}
+			client, err = assistantremote.New(ref.Registry, a.config.RegistryAuthPath, a.config.Insecure)
+			if err != nil {
+				return "", err
+			}
 		}
+
+		destPath := a.ociComponentPath(comp.Name, version)
+
+		// check if component is already in the cache
+		ok, err := utils.DirExists(destPath)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			puller := remotepuller.New(a.config.OciLayoutCache, client)
+			platform := simpleplatform.CurrentPlatform()
+			if a.overridePlatform != nil {
+				platform = a.overridePlatform
+			}
+			if err := puller.PullComponentByFullPath(ctx, ref.Repository, ref.Reference, destPath, platform); err != nil {
+				return "", err
+			}
+		}
+
+		if err := a.config.CacheIndex.Store(sha256Digest, comp.Name, version); err != nil {
+			return "", err
+		}
+
+		// if we had to append a sha, update the daml.yaml
+		if newUri != "" {
+			if comp.YamlEditTarget == nil {
+				return "", fmt.Errorf("could not update project's daml.yaml or multi-package.yaml with component's sha for component %q as the need info to edit the yaml file is missing", uri)
+			}
+			yamledit.EditYaml(*comp.YamlEditTarget, newUri)
+		}
+
+		return destPath, nil
+	} else {
+		digest, err := ref.Digest()
+		if err != nil {
+			// legacy case where uris didn't yet have digest
+			// we'll fall back to not relying on CacheIndex
+			fmt.Fprintln(os.Stderr, "warn: dpm now attaches @sha256 digest to OCI URIs. Please run 'dpm install' to have dpm update your daml.yaml / component.yaml")
+
+			// TODO
+			return "TODO", nil
+		}
+
+		_, version, ok, err := a.config.CacheIndex.Get(digest.String())
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", fmt.Errorf("component %q is currently not installed.  Run `dpm install package` to install", comp.String())
+		}
+
+		destPath := a.ociComponentPath(comp.Name, version)
+		ok, err = utils.DirExists(destPath)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", fmt.Errorf("component %q is currently not installed.  Run `dpm install package` to install", comp.String())
+		}
+
+		return destPath, nil
 	}
-	return a.handleURI(ctx, ref, comp)
 }
 
-func (a *Assembler) handleURI(ctx context.Context, ref registry.Reference, comp *sdkmanifest.Component) (string, error) {
-	destPath := a.ociComponentPath(fmt.Sprintf("%s/%s", ref.Registry, ref.Repository), ref.Reference)
-
-	// TODO - Rip out for floaty support, add tests to ensure things work
-	if !strings.Contains(ref.Reference, "sha256:") {
-		_, err := semver.StrictNewVersion(ref.Reference)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse %q as strict semantic version in %q: %w", ref.Reference, *comp.Uri, err)
-		}
-	}
+func (a *Assembler) handleOCI(ctx context.Context, comp *sdkmanifest.Component) (string, error) {
+	destPath := a.ociComponentPath(comp.Name, comp.Version.Value().String())
+	tag := ComputeTagOrDigest(comp)
 
 	// check if component is already in the cache
 	ok, err := utils.DirExists(destPath)
@@ -408,134 +477,28 @@ func (a *Assembler) handleURI(ctx context.Context, ref registry.Reference, comp 
 	}
 	if !ok {
 		if _, isRemote := a.puller.(*remotepuller.RemoteOciPuller); isRemote && !a.config.AutoInstall {
-			return "", fmt.Errorf("component %s is currently not installed.  Run `dpm install package` to install", comp.Name)
+			return "", fmt.Errorf("component %q is currently not installed.  Run `dpm install package` to install", comp.String())
 		}
 		platform := simpleplatform.CurrentPlatform()
 		if a.overridePlatform != nil {
 			platform = a.overridePlatform
 		}
-
-		customRemote, err := assistantremote.New(ref.Registry, a.config.RegistryAuthPath, a.config.Insecure)
-		if err != nil {
+		fmt.Printf("pulling sdk component %s %s...\n", comp.Name, tag)
+		if err := a.puller.PullComponent(ctx, comp.Name, tag, destPath, platform); err != nil {
 			return "", err
 		}
-
-		// Passing in old config layoutCache
-		customPuller := remotepuller.New(a.config.OciLayoutCache, customRemote)
-
-		_, err = digest.Parse(ref.Reference)
-		if err != nil {
-			descDigest, err := customPuller.GetManifest(ctx, ref.Repository, ref.Reference, platform)
-			if err != nil {
-				return "", err
-			}
-
-			destPath = a.ociComponentPath(comp.Name, descDigest.Digest.String())
-		}
-		fmt.Printf("pulling sdk component %s %s ...\n", comp.Name, *comp.Uri)
-
-		_, err = customPuller.PullComponentByFullPath(ctx, ref.Repository, ref.Reference, destPath, platform)
-		if err != nil {
-			return "", err
-		}
-	}
-	return destPath, nil
-}
-
-func (a *Assembler) HandleOCI(ctx context.Context, comp *sdkmanifest.Component) (string, error) {
-	if comp.Version != nil {
-		ref, found, err := a.FindManifestByAnnotation(comp.Name, comp.Version.Value().String())
-		if err != nil {
-			return "", err
-		}
-		if found {
-			return a.handleOCI(ctx, comp.Name, ref)
-		}
-		return a.handleOCI(ctx, comp.Name, comp.Version.Value().String())
-	}
-
-	return a.handleOCI(ctx, comp.Name, comp.Digest.String())
-}
-
-func (a *Assembler) handleOCI(ctx context.Context, compName string, reference string) (string, error) {
-	destPath := a.ociComponentPath(compName, reference)
-
-	ok, err := utils.DirExists(destPath)
-	if err != nil {
-		return "", err
-	}
-	if !ok {
-		if _, isRemote := a.puller.(*remotepuller.RemoteOciPuller); isRemote && !a.config.AutoInstall {
-			return "", fmt.Errorf("component %q is currently not installed.  Run `dpm install package` to install", compName)
-		}
-		platform := simpleplatform.CurrentPlatform()
-		if a.overridePlatform != nil {
-			platform = a.overridePlatform
-		}
-
-		_, err := digest.Parse(reference)
-		if err != nil {
-			descDigest, err := a.puller.GetManifest(ctx, ociconsts.ComponentRepoPrefix+compName, reference, platform)
-			if err != nil {
-				return "", err
-			}
-
-			destPath = a.ociComponentPath(compName, descDigest.Digest.String())
-		}
-		fmt.Printf("pulling sdk component %s %s...\n", compName, reference)
-
-		_, err = a.puller.PullComponent(ctx, compName, reference, destPath, platform)
-		if err != nil {
-			return "", err
-		}
-
 	}
 
 	return destPath, nil
-}
-
-func (a *Assembler) FindManifestByAnnotation(name string, value string) (string, bool, error) {
-	indexPath := filepath.Join(a.config.CachePath, "oci-layout/index.json")
-	_, err := os.Stat(indexPath)
-	// no oci-layout initialized
-	if os.IsNotExist(err) {
-		return "", false, nil
-	}
-
-	data, err := os.ReadFile(filepath.Join(a.config.CachePath, "oci-layout/index.json"))
-	if err != nil {
-		return "", false, fmt.Errorf("failed to read file: %w", err)
-	}
-
-	var index ocispec.Index
-	if err := json.Unmarshal(data, &index); err != nil {
-		return "", false, fmt.Errorf("failed to unmarshal index: %w", err)
-	}
-
-	for _, desc := range index.Manifests {
-		if desc.Annotations == nil {
-			continue
-		}
-
-		if artifactName, nameFound := desc.Annotations[ociconsts.DescriptorNameAnnotation]; nameFound && artifactName == name {
-			if version, versionFound := desc.Annotations[v1.AnnotationVersion]; versionFound && version == value {
-				return desc.Digest.String(), true, nil
-			}
-		}
-	}
-
-	return "", false, nil
 }
 
 func ComputeTagOrDigest(comp *sdkmanifest.Component) string {
-	if comp.Digest != nil {
-		return comp.Digest.String()
-	}
+	// TODO fully flesh this out
 	return comp.Version.Value().String()
 }
 
-func (a *Assembler) ociComponentPath(componentUri string, reference string) string {
-	return filepath.Join(a.config.CachePath, "components", utils.UrlToFilePath(componentUri), strings.ReplaceAll(reference, ":", "_"))
+func (a *Assembler) ociComponentPath(componentUri string, tag string) string {
+	return filepath.Join(a.config.CachePath, "components", utils.UrlToFilePath(componentUri), tag)
 }
 
 // computeImports merges all components' component.Exports, taking into account their conflict strategy,

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -416,7 +416,7 @@ func (a *Assembler) handleURI(ctx context.Context, comp *sdkmanifest.Component) 
 			if a.overridePlatform != nil {
 				platform = a.overridePlatform
 			}
-			if err := puller.PullComponentByFullPath(ctx, ref.Repository, ref.Reference, destPath, platform); err != nil {
+			if _, err := puller.PullComponentByFullPath(ctx, ref.Repository, ref.Reference, destPath, platform); err != nil {
 				return "", err
 			}
 		}
@@ -484,7 +484,7 @@ func (a *Assembler) handleOCI(ctx context.Context, comp *sdkmanifest.Component) 
 			platform = a.overridePlatform
 		}
 		fmt.Printf("pulling sdk component %s %s...\n", comp.Name, tag)
-		if err := a.puller.PullComponent(ctx, comp.Name, tag, destPath, platform); err != nil {
+		if _, err := a.puller.PullComponent(ctx, comp.Name, tag, destPath, platform); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -25,6 +25,7 @@ import (
 	"daml.com/x/assistant/pkg/simpleplatform"
 	"daml.com/x/assistant/pkg/utils"
 	"daml.com/x/assistant/pkg/yamledit"
+	"github.com/Masterminds/semver/v3"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/samber/lo"
@@ -368,7 +369,6 @@ func (a *Assembler) handleURI(ctx context.Context, comp *sdkmanifest.Component) 
 	}
 
 	uri := *comp.Uri
-
 	ref, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
 	if err != nil {
 		return "", err
@@ -379,9 +379,7 @@ func (a *Assembler) handleURI(ctx context.Context, comp *sdkmanifest.Component) 
 		// legacy case where 'oci://' Uris hadn't yet supported digests.
 		// we'll fall back to not relying on CacheIndex and assume the legacy cache layout
 		fmt.Fprintln(os.Stderr, "warn: dpm now attaches @sha256 digest to OCI URIs. Please run 'dpm install' to have dpm update your daml.yaml / component.yaml")
-
-		// TODO
-		return "TODO", nil
+		return a.legacyUriComponentLookup(comp, ref)
 	}
 
 	destPath, ok, err := a.getFromCacheByDigest(comp, digest)
@@ -394,22 +392,37 @@ func (a *Assembler) handleURI(ctx context.Context, comp *sdkmanifest.Component) 
 	return destPath, nil
 }
 
-func (a *Assembler) installUriComp(ctx context.Context, comp *sdkmanifest.Component) (string, error) {
-	uri := *comp.Uri
+func (a *Assembler) legacyUriComponentLookup(comp *sdkmanifest.Component, ref registry.Reference) (string, error) {
+	version, err := semver.StrictNewVersion(ref.Reference)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse %q as strict semantic version in %q: %w", ref.Reference, *comp.Uri, err)
+	}
 
+	destPath := a.ociComponentPath(fmt.Sprintf("%s/%s", ref.Registry, ref.Repository), version.String())
+	ok, err := utils.DirExists(destPath)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("component %q is currently not installed.  Run `dpm install package` to install", comp.String())
+	}
+
+	return destPath, nil
+}
+
+func (a *Assembler) installUriComp(ctx context.Context, comp *sdkmanifest.Component) (string, error) {
+	var version, newUri string
+
+	uri := *comp.Uri
 	ref, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
 	if err != nil {
 		return "", err
 	}
 
-	var version string
-
 	client, err := assistantremote.New(ref.Registry, a.config.RegistryAuthPath, a.config.Insecure)
 	if err != nil {
 		return "", err
 	}
-
-	var newUri string
 
 	sha256Digest, digestErr := ref.Digest()
 
@@ -472,13 +485,14 @@ func (a *Assembler) installUriComp(ctx context.Context, comp *sdkmanifest.Compon
 	// if we had to append a sha, update the daml.yaml / component.yaml
 	if newUri != "" {
 		if comp.YamlEditTarget == nil {
-			return "", fmt.Errorf("could not update project's daml.yaml or multi-package.yaml with component's sha for component %q as the need info to edit the yaml file is missing", uri)
+			return "", fmt.Errorf("could not update project's daml.yaml or multi-package.yaml with component's sha for component %q as the needed info to edit the yaml file is missing", uri)
 		}
-		yamledit.EditYaml(*comp.YamlEditTarget, newUri)
+		if err := yamledit.EditYaml(*comp.YamlEditTarget, newUri); err != nil {
+			return "", err
+		}
 	}
 
 	return destPath, nil
-
 }
 
 func (a *Assembler) getFromCacheByDigest(comp *sdkmanifest.Component, d digest.Digest) (string, bool, error) {
@@ -525,7 +539,6 @@ func (a *Assembler) handleOCI(ctx context.Context, comp *sdkmanifest.Component) 
 }
 
 func ComputeTagOrDigest(comp *sdkmanifest.Component) string {
-	// TODO fully flesh this out
 	return comp.Version.Value().String()
 }
 

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -25,6 +25,7 @@ import (
 	"daml.com/x/assistant/pkg/simpleplatform"
 	"daml.com/x/assistant/pkg/utils"
 	"daml.com/x/assistant/pkg/yamledit"
+	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/samber/lo"
 	"oras.land/oras-go/v2/registry"
@@ -362,6 +363,10 @@ func (a *Assembler) handleLocalDir(basePath, componentPath string) string {
 }
 
 func (a *Assembler) handleURI(ctx context.Context, comp *sdkmanifest.Component) (string, error) {
+	if a.config.AutoInstall {
+		return a.installUriComp(ctx, comp)
+	}
+
 	uri := *comp.Uri
 
 	ref, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
@@ -369,101 +374,128 @@ func (a *Assembler) handleURI(ctx context.Context, comp *sdkmanifest.Component) 
 		return "", err
 	}
 
-	if a.config.AutoInstall {
-		var version string
+	digest, err := ref.Digest()
+	if err != nil {
+		// legacy case where 'oci://' Uris hadn't yet supported digests.
+		// we'll fall back to not relying on CacheIndex and assume the legacy cache layout
+		fmt.Fprintln(os.Stderr, "warn: dpm now attaches @sha256 digest to OCI URIs. Please run 'dpm install' to have dpm update your daml.yaml / component.yaml")
 
-		client, err := assistantremote.New(ref.Registry, a.config.RegistryAuthPath, a.config.Insecure)
-		if err != nil {
-			return "", err
-		}
-
-		var newUri string
-
-		sha256Digest, digestErr := ref.Digest()
-
-		// if the URI doesn't already have a sha256, give it one.
-		// (this does not necessarily mean we're gonna bump dependencies)
-		if digestErr != nil {
-			resolvedDigest, ociManifest, err := ocilister.FetchManifest(ctx, client, ref)
-			if err != nil {
-				return "", err
-			}
-			sha256Digest = resolvedDigest
-			version = ociManifest.Annotations[v1.AnnotationVersion]
-			newUri = uri + "@" + resolvedDigest.String()
-
-			// update client and ref
-			ref, err = registry.ParseReference(strings.TrimPrefix(newUri, "oci://"))
-			if err != nil {
-				return "", err
-			}
-			client, err = assistantremote.New(ref.Registry, a.config.RegistryAuthPath, a.config.Insecure)
-			if err != nil {
-				return "", err
-			}
-		}
-
-		destPath := a.ociComponentPath(comp.Name, version)
-
-		// check if component is already in the cache
-		ok, err := utils.DirExists(destPath)
-		if err != nil {
-			return "", err
-		}
-		if !ok {
-			puller := remotepuller.New(a.config.OciLayoutCache, client)
-			platform := simpleplatform.CurrentPlatform()
-			if a.overridePlatform != nil {
-				platform = a.overridePlatform
-			}
-			if _, err := puller.PullComponentByFullPath(ctx, ref.Repository, ref.Reference, destPath, platform); err != nil {
-				return "", err
-			}
-		}
-
-		if err := a.config.CacheIndex.Store(sha256Digest, comp.Name, version); err != nil {
-			return "", err
-		}
-
-		// if we had to append a sha, update the daml.yaml
-		if newUri != "" {
-			if comp.YamlEditTarget == nil {
-				return "", fmt.Errorf("could not update project's daml.yaml or multi-package.yaml with component's sha for component %q as the need info to edit the yaml file is missing", uri)
-			}
-			yamledit.EditYaml(*comp.YamlEditTarget, newUri)
-		}
-
-		return destPath, nil
-	} else {
-		digest, err := ref.Digest()
-		if err != nil {
-			// legacy case where uris didn't yet have digest
-			// we'll fall back to not relying on CacheIndex
-			fmt.Fprintln(os.Stderr, "warn: dpm now attaches @sha256 digest to OCI URIs. Please run 'dpm install' to have dpm update your daml.yaml / component.yaml")
-
-			// TODO
-			return "TODO", nil
-		}
-
-		_, version, ok, err := a.config.CacheIndex.Get(digest.String())
-		if err != nil {
-			return "", err
-		}
-		if !ok {
-			return "", fmt.Errorf("component %q is currently not installed.  Run `dpm install package` to install", comp.String())
-		}
-
-		destPath := a.ociComponentPath(comp.Name, version)
-		ok, err = utils.DirExists(destPath)
-		if err != nil {
-			return "", err
-		}
-		if !ok {
-			return "", fmt.Errorf("component %q is currently not installed.  Run `dpm install package` to install", comp.String())
-		}
-
-		return destPath, nil
+		// TODO
+		return "TODO", nil
 	}
+
+	destPath, ok, err := a.getFromCacheByDigest(comp, digest)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("component %q is currently not installed.  Run `dpm install package` to install", comp.String())
+	}
+	return destPath, nil
+}
+
+func (a *Assembler) installUriComp(ctx context.Context, comp *sdkmanifest.Component) (string, error) {
+	uri := *comp.Uri
+
+	ref, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
+	if err != nil {
+		return "", err
+	}
+
+	var version string
+
+	client, err := assistantremote.New(ref.Registry, a.config.RegistryAuthPath, a.config.Insecure)
+	if err != nil {
+		return "", err
+	}
+
+	var newUri string
+
+	sha256Digest, digestErr := ref.Digest()
+
+	// if the URI doesn't already have a sha256, give it one.
+	// (this does not necessarily mean we're gonna bump dependencies. This method never changes existing SHAs!)
+	if digestErr != nil {
+		resolvedDigest, ociManifest, err := ocilister.FetchManifest(ctx, client, ref)
+		if err != nil {
+			return "", err
+		}
+		sha256Digest = resolvedDigest
+		version = ociManifest.Annotations[v1.AnnotationVersion]
+		newUri = uri + "@" + resolvedDigest.String()
+
+		// update client and ref
+		ref, err = registry.ParseReference(strings.TrimPrefix(newUri, "oci://"))
+		if err != nil {
+			return "", err
+		}
+		client, err = assistantremote.New(ref.Registry, a.config.RegistryAuthPath, a.config.Insecure)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		// The uri has a sha already.
+
+		destPath, ok, err := a.getFromCacheByDigest(comp, sha256Digest)
+		if err != nil {
+			return "", err
+		}
+		// if it had been downloaded already, and we could fetch it from the cache, we're done
+		if ok {
+			return destPath, nil
+		}
+
+		// otherwise we're gonna have to pull it anyway.
+		// we'll resolve again despite already knowing the SHA, because we need to get the version
+		_, ociManifest, err := ocilister.FetchManifest(ctx, client, ref)
+		if err != nil {
+			return "", err
+		}
+		version = ociManifest.Annotations[v1.AnnotationVersion]
+	}
+
+	destPath := a.ociComponentPath(comp.Name, version)
+
+	puller := remotepuller.New(a.config.OciLayoutCache, client)
+	platform := simpleplatform.CurrentPlatform()
+	if a.overridePlatform != nil {
+		platform = a.overridePlatform
+	}
+	if _, err := puller.PullComponentByFullPath(ctx, ref.Repository, ref.Reference, destPath, platform); err != nil {
+		return "", err
+	}
+
+	if err := a.config.CacheIndex.Store(sha256Digest, comp.Name, version); err != nil {
+		return "", err
+	}
+
+	// if we had to append a sha, update the daml.yaml / component.yaml
+	if newUri != "" {
+		if comp.YamlEditTarget == nil {
+			return "", fmt.Errorf("could not update project's daml.yaml or multi-package.yaml with component's sha for component %q as the need info to edit the yaml file is missing", uri)
+		}
+		yamledit.EditYaml(*comp.YamlEditTarget, newUri)
+	}
+
+	return destPath, nil
+
+}
+
+func (a *Assembler) getFromCacheByDigest(comp *sdkmanifest.Component, d digest.Digest) (string, bool, error) {
+	_, version, ok, err := a.config.CacheIndex.Get(d.String())
+	if err != nil {
+		return "", false, err
+	}
+	if !ok {
+		return "", false, nil
+	}
+
+	destPath := a.ociComponentPath(comp.Name, version)
+	ok, err = utils.DirExists(destPath)
+	if err != nil {
+		return "", false, err
+	}
+	return destPath, ok, nil
 }
 
 func (a *Assembler) handleOCI(ctx context.Context, comp *sdkmanifest.Component) (string, error) {

--- a/pkg/assistantconfig/config.go
+++ b/pkg/assistantconfig/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"daml.com/x/assistant/cmd/dpm/cmd/resolve/resolutionerrors"
+	"daml.com/x/assistant/pkg/cacheindex"
 	"daml.com/x/assistant/pkg/sdkmanifest"
 	"oras.land/oras-go/v2/registry"
 
@@ -56,6 +57,8 @@ type Config struct {
 	Registry         string `yaml:"registry,omitempty"`
 	RegistryAuthPath string `yaml:"registry-auth-path,omitempty"`
 	Insecure         bool   `yaml:"insecure,omitempty"`
+
+	CacheIndex *cacheindex.CacheIndex `yaml:"-"`
 }
 
 func (c *Config) SdkManifestsRepo() (string, error) {
@@ -67,10 +70,15 @@ func (c *Config) SdkManifestsRepo() (string, error) {
 }
 
 func (c *Config) EnsureDirs() error {
-	return utils.EnsureDirs(c.DamlHomePath, c.OciLayoutCache,
+	err := utils.EnsureDirs(c.DamlHomePath, c.OciLayoutCache,
 		filepath.Join(c.InstalledSdkManifestsPath, sdkmanifest.Enterprise.String()),
 		filepath.Join(c.InstalledSdkManifestsPath, sdkmanifest.Private.String()),
 		filepath.Join(c.InstalledSdkManifestsPath, sdkmanifest.OpenSource.String()))
+	if err != nil {
+		return err
+	}
+
+	return c.CacheIndex.Init()
 }
 
 func Get() (*Config, error) {
@@ -154,6 +162,9 @@ func GetWithCustomDamlHome(dpmHomePath string) (*Config, error) {
 	config.OciLayoutCache = filepath.Join(cacheDir, "oci-layout")
 	config.InstalledSdkManifestsPath = filepath.Join(cacheDir, "sdk")
 	config.InstallLocalFilePath = filepath.Join(config.InstalledSdkManifestsPath, ".lock")
+	config.CacheIndex = &cacheindex.CacheIndex{
+		AbsolutePath: filepath.Join(cacheDir, "index.json"),
+	}
 	return &config, nil
 }
 

--- a/pkg/cacheindex/cacheindex.go
+++ b/pkg/cacheindex/cacheindex.go
@@ -1,0 +1,128 @@
+package cacheindex
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"daml.com/x/assistant/pkg/utils"
+	"github.com/opencontainers/go-digest"
+)
+
+const CacheIndexSchema = "cache-index/v1"
+
+type CacheIndex struct {
+	AbsolutePath string
+}
+
+type CacheIndexContents struct {
+	Schema     string                         `json:"schema"`
+	Components map[string]CacheIndexComponent `json:"components"`
+}
+
+type CacheIndexComponent struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func (c *CacheIndex) Store(d digest.Digest, name, version string) error {
+	if err := d.Validate(); err != nil {
+		return err
+	}
+
+	contents, err := c.read()
+	if err != nil {
+		return err
+	}
+
+	contents.Components[d.String()] = CacheIndexComponent{
+		Name:    name,
+		Version: version,
+	}
+
+	return c.write(contents)
+}
+
+// Init writes an empty cache index if one doesn't already exist.
+func (c *CacheIndex) Init() error {
+	if _, err := os.Stat(c.AbsolutePath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	if err := utils.EnsureDirs(filepath.Dir(c.AbsolutePath)); err != nil {
+		return err
+	}
+
+	contents := &CacheIndexContents{
+		Schema:     CacheIndexSchema,
+		Components: map[string]CacheIndexComponent{},
+	}
+
+	return c.write(contents)
+}
+
+func (c *CacheIndex) Get(digest string) (name string, version string, ok bool, err error) {
+	if !strings.HasPrefix(digest, "sha256:") {
+		return "", "", false, fmt.Errorf("the digest to read from the cache index must be a sha256 digest with the 'sha256:' prefix")
+	}
+
+	if err := c.Init(); err != nil {
+		return "", "", false, err
+	}
+
+	contents, err := c.read()
+	if err != nil {
+		return "", "", false, err
+	}
+
+	component, ok := contents.Components[digest]
+	if !ok {
+		return "", "", false, nil
+	}
+
+	return component.Name, component.Version, true, nil
+}
+
+// read assumes the index file already exists.
+func (c *CacheIndex) read() (*CacheIndexContents, error) {
+	b, err := os.ReadFile(c.AbsolutePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var contents CacheIndexContents
+	if err := json.Unmarshal(b, &contents); err != nil {
+		return nil, err
+	}
+
+	if contents.Components == nil {
+		contents.Components = map[string]CacheIndexComponent{}
+	}
+
+	if contents.Schema == "" {
+		contents.Schema = CacheIndexSchema
+	}
+
+	return &contents, nil
+}
+
+func (c *CacheIndex) write(contents *CacheIndexContents) error {
+	if contents.Schema == "" {
+		contents.Schema = CacheIndexSchema
+	}
+
+	if contents.Components == nil {
+		contents.Components = map[string]CacheIndexComponent{}
+	}
+
+	b, err := json.Marshal(contents)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(c.AbsolutePath, b, 0o644)
+}

--- a/pkg/cacheindex/cacheindex.go
+++ b/pkg/cacheindex/cacheindex.go
@@ -23,8 +23,12 @@ type CacheIndexContents struct {
 }
 
 type CacheIndexComponent struct {
-	Name    string `json:"name"`
 	Version string `json:"version"`
+
+	// this is not needed but is being included because having it will allow us
+	// to make bold changes if we want to better flesh out / overhaul the concept of "name"
+	// in dpm in the future
+	Name string `json:"name"`
 }
 
 func (c *CacheIndex) Store(d digest.Digest, name, version string) error {

--- a/pkg/componentlist/componentlist.go
+++ b/pkg/componentlist/componentlist.go
@@ -9,7 +9,6 @@ import (
 	"daml.com/x/assistant/pkg/yamledit"
 	"github.com/Masterminds/semver/v3"
 	"github.com/goccy/go-yaml"
-	"github.com/opencontainers/go-digest"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -114,23 +113,7 @@ func fromStringBasedComponent(c string) (string, *sdkmanifest.Component, error) 
 
 		return name, &sdkmanifest.Component{Name: name, Uri: &c}, nil
 	} else if strings.Contains(c, "@") && !strings.Contains(c, "/") {
-		// e.g "damlc@sha256:abc123" "damlc:123@sha256:abc1234"
-		parts := strings.Split(c, "@")
-
-		name, sha := parts[0], parts[1]
-
-		trimmedName, _, found := strings.Cut(name, ":")
-		if found {
-			// handle damlc:1.2.3@sha256:abc1234 case by trimming the version from the name
-			name = trimmedName
-		}
-
-		dg, err := digest.Parse(sha)
-		if err != nil {
-			return "", nil, fmt.Errorf("couldn't parse component %q: %w", c, err)
-		}
-
-		return name, &sdkmanifest.Component{Name: name, Digest: &dg}, nil
+		return "", nil, fmt.Errorf("invalid uri: currently, opt-in components that have '@sha256' must have fully-qualified uri beginning with 'oci://'")
 	} else if strings.Contains(c, ":") && !strings.Contains(c, "/") {
 		// e.g. "damlc:1.2.3"
 		parts := strings.Split(c, ":")
@@ -138,7 +121,7 @@ func fromStringBasedComponent(c string) (string, *sdkmanifest.Component, error) 
 
 		semVer, err := semver.StrictNewVersion(version)
 		if err != nil {
-			return "", nil, fmt.Errorf("couldn't parse component %q: %w", c, err)
+			return "", nil, fmt.Errorf("couldn't parse component's %q tag as semver (for floaty-tags, use fully-qualified 'oci://' URIs): %w", c, err)
 		}
 
 		return name, &sdkmanifest.Component{Name: name, Version: sdkmanifest.AssemblySemVer(semVer)}, nil

--- a/pkg/componentlist/componentlist.go
+++ b/pkg/componentlist/componentlist.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"daml.com/x/assistant/pkg/sdkmanifest"
+	"daml.com/x/assistant/pkg/yamledit"
 	"github.com/Masterminds/semver/v3"
 	"github.com/goccy/go-yaml"
 	"github.com/opencontainers/go-digest"
@@ -53,15 +54,22 @@ func (e *ComponentEntry) MarshalYAML() (any, error) {
 	}
 }
 
-func (compList ComponentList) ToMap() (map[string]*sdkmanifest.Component, error) {
+func (compList ComponentList) ToMap(yamlEditTarget *yamledit.YamlTarget) (map[string]*sdkmanifest.Component, error) {
 	compMap := make(map[string]*sdkmanifest.Component)
 	var errs []error
 
-	for _, entry := range compList {
+	for i, entry := range compList {
 		name, comp, err := entry.toComponent()
 		if err != nil {
 			errs = append(errs, err)
 			continue
+		}
+		if yamlEditTarget != nil {
+			comp.YamlEditTarget = &yamledit.YamlTarget{
+				YamlFilePath: yamlEditTarget.YamlFilePath,
+				FieldName:    yamlEditTarget.FieldName,
+				Index:        i,
+			}
 		}
 		compMap[name] = comp
 	}

--- a/pkg/componentlist/componentlist_test.go
+++ b/pkg/componentlist/componentlist_test.go
@@ -19,7 +19,7 @@ func TestComponentList(t *testing.T) {
 	m := Manifest{}
 	require.NoError(t, yaml.Unmarshal(testdata.Valid, &m))
 
-	cs, err := m.Components.ToMap()
+	cs, err := m.Components.ToMap(nil)
 	require.NoError(t, err)
 
 	assert.Len(t, cs, 4)

--- a/pkg/damlpackage/damlproject.go
+++ b/pkg/damlpackage/damlproject.go
@@ -11,6 +11,7 @@ import (
 
 	"daml.com/x/assistant/pkg/componentlist"
 	"daml.com/x/assistant/pkg/sdkmanifest"
+	"daml.com/x/assistant/pkg/yamledit"
 	"github.com/goccy/go-yaml"
 )
 
@@ -59,7 +60,10 @@ func ReadFromContents(contents []byte, absoluteFilePath string) (*DamlPackage, e
 	obj.AbsolutePath = absoluteFilePath
 
 	if obj.ComponentsList != nil {
-		obj.Components, err = obj.ComponentsList.ToMap()
+		obj.Components, err = obj.ComponentsList.ToMap(&yamledit.YamlTarget{
+			YamlFilePath: absoluteFilePath,
+			FieldName:    "components",
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/multipackage/multipackage.go
+++ b/pkg/multipackage/multipackage.go
@@ -12,6 +12,7 @@ import (
 	"daml.com/x/assistant/pkg/componentlist"
 	"daml.com/x/assistant/pkg/sdkmanifest"
 	"daml.com/x/assistant/pkg/utils"
+	"daml.com/x/assistant/pkg/yamledit"
 	"github.com/goccy/go-yaml"
 	"github.com/samber/lo"
 )
@@ -75,7 +76,10 @@ func ReadFromContents(contents []byte, absPath string) (*MultiPackage, error) {
 	}
 
 	if obj.ComponentsList != nil {
-		obj.Components, err = obj.ComponentsList.ToMap()
+		obj.Components, err = obj.ComponentsList.ToMap(&yamledit.YamlTarget{
+			YamlFilePath: absPath,
+			FieldName:    "components",
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ocilister/lister.go
+++ b/pkg/ocilister/lister.go
@@ -15,6 +15,7 @@ import (
 	"daml.com/x/assistant/pkg/ociindex"
 	"daml.com/x/assistant/pkg/sdkmanifest"
 	"github.com/Masterminds/semver/v3"
+	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/samber/lo"
 	"oras.land/oras-go/v2/content"
@@ -119,31 +120,31 @@ func isErrorCode(err error, code string) bool {
 	return errors.As(err, &ec) && ec.Code == code
 }
 
-func FetchManifest(ctx context.Context, client *assistantremote.Remote, ref registry.Reference) (*v1.Descriptor, error) {
+func FetchManifest(ctx context.Context, client *assistantremote.Remote, ref registry.Reference) (digest.Digest, v1.Manifest, error) {
 	repo, err := client.Repo(ref.Repository)
 	if err != nil {
-		return nil, err
+		return "", v1.Manifest{}, err
 	}
 	desc, err := repo.Resolve(ctx, ref.Reference)
 	if err != nil {
-		return nil, err
+		return "", v1.Manifest{}, err
 	}
 
 	rc, err := repo.Fetch(ctx, desc)
 	if err != nil {
-		return nil, err
+		return "", v1.Manifest{}, err
 	}
 	defer rc.Close()
 
 	manifestBytes, err := content.ReadAll(rc, desc)
 	if err != nil {
-		return nil, err
+		return "", v1.Manifest{}, err
 	}
 
 	var manifest v1.Manifest
 	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
-		return nil, err
+		return "", v1.Manifest{}, err
 	}
 
-	return &desc, nil
+	return desc.Digest, manifest, nil
 }

--- a/pkg/sdkmanifest/spec.go
+++ b/pkg/sdkmanifest/spec.go
@@ -6,6 +6,7 @@ package sdkmanifest
 import (
 	"fmt"
 
+	"daml.com/x/assistant/pkg/yamledit"
 	"github.com/goccy/go-yaml"
 	"github.com/opencontainers/go-digest"
 )
@@ -75,6 +76,8 @@ type Component struct {
 	ImageTag  *string `yaml:"image-tag,omitempty"`
 	LocalPath *string `yaml:"local-path,omitempty"`
 	Uri       *string `yaml:"uri,omitempty"`
+
+	YamlEditTarget *yamledit.YamlTarget `yaml:"-"`
 }
 
 // String returns representation meant for humans

--- a/pkg/sdkmanifest/spec.go
+++ b/pkg/sdkmanifest/spec.go
@@ -8,7 +8,6 @@ import (
 
 	"daml.com/x/assistant/pkg/yamledit"
 	"github.com/goccy/go-yaml"
-	"github.com/opencontainers/go-digest"
 )
 
 const AssistantName = "dpm" // this is also the OCI repo name
@@ -64,9 +63,8 @@ func (s *Spec) UnmarshalYAML(bytes []byte) error {
 }
 
 type Component struct {
-	Name    string         `yaml:"-"`
-	Version *SemVer        `yaml:"version,omitempty"`
-	Digest  *digest.Digest `yaml:"digest,omitempty"`
+	Name    string  `yaml:"-"`
+	Version *SemVer `yaml:"version,omitempty"`
 
 	// We don't yet have support for floaty or arbitrary tags (as that requires lockfiles),
 	// but the `dpm resolve-tags` command used in the assembly process for putting together

--- a/pkg/testutil/testdata/multi-pinning/unix/daml.yaml
+++ b/pkg/testutil/testdata/multi-pinning/unix/daml.yaml
@@ -1,4 +1,3 @@
 components:
     - ${TEST_DPM_REGISTRY}/foo/bar/meep:1.2.3@${TEST_MEEP_SHA}
     - ${TEST_DPM_REGISTRY}/bar/foo/rando@${TEST_RANDO_SHA}
-    - javabro:6.7.8@${TEST_JAVA_SHA}

--- a/pkg/testutil/testdata/multi-pinning/windows/daml.yaml
+++ b/pkg/testutil/testdata/multi-pinning/windows/daml.yaml
@@ -1,4 +1,3 @@
 components:
   - ${TEST_DPM_REGISTRY}/foo/bar/meep:1.2.3@${TEST_MEEP_SHA}
   - ${TEST_DPM_REGISTRY}/bar/foo/rando@${TEST_RANDO_SHA}
-  - javabro:6.7.8@${TEST_JAVA_SHA}

--- a/pkg/testutil/testdata/multi-registry/daml.yaml
+++ b/pkg/testutil/testdata/multi-registry/daml.yaml
@@ -2,5 +2,3 @@ components:
     - ${TEST_DPM_REGISTRY}/foo/bar/meep:1.2.3
     - ${TEST_ALT_DPM_REGISTRY}/bar/foo/rando:1.2.4
     - javabro:6.7.8
-    - name: my-local-component
-      path: ../../another-generic-component

--- a/pkg/testutil/testdata/multi-registry/windows/daml.yaml
+++ b/pkg/testutil/testdata/multi-registry/windows/daml.yaml
@@ -1,6 +1,0 @@
-components:
-  - ${TEST_DPM_REGISTRY}/foo/bar/meep:1.2.3
-  - ${TEST_ALT_DPM_REGISTRY}/bar/foo/rando:1.2.4
-  - javabro:6.7.8
-  - name: my-local-component
-    path: ../../another-generic-component

--- a/pkg/yamledit/yamledit.go
+++ b/pkg/yamledit/yamledit.go
@@ -13,19 +13,20 @@ import (
 type YamlTarget struct {
 	YamlFilePath string
 	FieldName    string
+	Index        int
 }
 
 // EditYaml adds an item to list in yaml file
 // or replace the given index with it
-func EditYaml(info YamlTarget, item string, index int) error {
+func EditYaml(info YamlTarget, item string) error {
 	b, err := os.ReadFile(info.YamlFilePath)
 	if err != nil {
 		return err
 	}
 
 	var out string
-	if index != -1 {
-		out, err = ReplaceItemInList(b, info.FieldName, index, item)
+	if info.Index != -1 {
+		out, err = ReplaceItemInList(b, info.FieldName, info.Index, item)
 	} else {
 		out, err = AddToList(b, info.FieldName, item)
 	}


### PR DESCRIPTION
-  `dpm install`  will now auto append `@sha256:` to `oci://` components that don't have shas
    - out-of-scope corner case: preserving the env var in `- oci://${SOME_ENV_VAR}/foo/bar/baz:1.2.3`. `dpm install` will expand the env var when it updates the `daml.yaml`. This is okay, because really the better way to support this use case is to implement `@alias` support for opt-in components instead of relying on env vars for this use case.
- redo the cache for opt-in components that have `@sha256`: 
  -  stop relying on `oci-layout` for mapping sha to `name` / `version` as we might get rid of `oci-layout`, and also because the way we're doing the lookup is not very robust (it's relying on the concept of `name`, but the name used during publishing, which is different from the name used during `resolve`. The concept of "name" in dpm needs more thought)
  - instead, manually store the mapping using a simple json file
  - fixes handling of sdk components in existing cache dirs, as i believe that's broken on `main` atm. 
- shorthand opt-in components that don't begin with `oci://` will not be affected and will behave as they did a week ago, but as a caveat, they won't support sha-pinning. This is left for future improvement (and this PR won't make it any harder to add support for them in the future. Perhaps we'll even stop supporting this shorthand altogether and go with `@alias` as mentioned earlier)


# Demo
```
Installing components...
time=2026-06-21T12:10:12.574-04:00 level=INFO msg="using custom auth for registry" path=/Users/sammyabed/dpm/pkg/testutil/testdata/empty-docker-config.json
2026/06/21 12:10:15 HEAD /v2/newly/added/manifests/4.5.6
2026/06/21 12:10:15 GET /v2/newly/added/manifests/sha256:f97a5f8bfe580b6b3f02418e6ce851efd5cf9fbcf63327b3662794af42d15434
time=2026-06-21T12:10:15.116-04:00 level=INFO msg="using custom auth for registry" path=/Users/sammyabed/dpm/pkg/testutil/testdata/empty-docker-config.json
2026/06/21 12:10:26 GET /v2/newly/added/manifests/sha256:f97a5f8bfe580b6b3f02418e6ce851efd5cf9fbcf63327b3662794af42d15434
2026/06/21 12:10:26 GET /v2/newly/added/manifests/sha256:f97a5f8bfe580b6b3f02418e6ce851efd5cf9fbcf63327b3662794af42d15434
2026/06/21 12:10:26 GET /v2/newly/added/manifests/sha256:bf4637fe0020cb2140434fe69be5ed22694af003a5539868d8ffa027fc85c2db
2026/06/21 12:10:26 GET /v2/newly/added/blobs/sha256:e39031bb80818110853aa0dc5a367a0ff09fd753ebb22b1aae4715e61d4c8e4e
2026/06/21 12:10:26 GET /v2/newly/added/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
2026/06/21 12:10:26 GET /v2/newly/added/blobs/sha256:44879cbe9668207c954713eeae6013e02562f69ed59b6fbbc358c735b2ca5996
2026/06/21 12:10:26 GET /v2/newly/added/blobs/sha256:a72ccb2e95e6eb60f8aca3a67b04b5ff9278219b569d862ab3a8d33c00d9f3fb
2026/06/21 12:10:26 GET /v2/newly/added/blobs/sha256:e20c85d136e4a36168f16fad0e305dafc5164a463bbe3996a18cc366611f214c
2026/06/21 12:10:26 GET /v2/newly/added/blobs/sha256:3164be774369c36a4a0c65ae279a31ba765835a18b08df5aa879c984717b8fc9
Successfully installed opt-in components
```

```diff
diff --git a/daml.yaml b/daml.yaml
index c78a49b..45ca2f3 100644
--- a/daml.yaml
+++ b/daml.yaml
@@ -1,3 +1,2 @@
-
 components:
-  - oci://127.0.0.1:63506/newly/added:4.5.6
+  - oci://127.0.0.1:63506/newly/added:4.5.6@sha256:f97a5f8bfe580b6b3f02418e6ce851efd5cf9fbcf63327b3662794af42d15434
```