### PR TITLE
fix broken main for existing sdk

### DIFF
--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -5,18 +5,19 @@ package assembler
 
 import (
 	"context"
-	ociconsts "daml.com/x/assistant/pkg/oci"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Masterminds/semver/v3"
-	"github.com/opencontainers/go-digest"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
 	"strings"
+
+	ociconsts "daml.com/x/assistant/pkg/oci"
+	"github.com/Masterminds/semver/v3"
+	"github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
 	"daml.com/x/assistant/pkg/assistantconfig/assistantremote"
@@ -449,7 +450,17 @@ func (a *Assembler) HandleOCI(ctx context.Context, comp *sdkmanifest.Component) 
 			return "", err
 		}
 		if found {
-			return a.handleOCI(ctx, comp.Name, ref)
+			path := a.ociComponentPath(comp.Name, ref)
+
+			ok, err := utils.DirExists(path)
+
+			// if we cannot find by digest fall through to version
+			if err != nil {
+				return a.handleOCI(ctx, comp.Name, comp.Version.Value().String())
+			}
+			if ok {
+				return a.handleOCI(ctx, comp.Name, ref)
+			}
 		}
 		return a.handleOCI(ctx, comp.Name, comp.Version.Value().String())
 	}


### PR DESCRIPTION
main currently fails if you have an existing SDK

add fall through logic looking for cache by version to deal with this case


```
❯ make
go mod download
go run cmd/dpm/main.go --version
time=2026-06-20T19:49:59.763-04:00 level=DEBUG msg="no custom registry auth provided. Will default to docker's if present on system"
time=2026-06-20T19:49:59.766-04:00 level=DEBUG msg="deep resolution file written" path=/var/folders/sd/1hfghl6j5qx93zml7xcwzqx00000gq/T/nix-shell.LDjCv5/1184825478.yaml
error handling component "canton-open-source" in "/Users/jimmyjam/.dpm/cache/sdk/open-source/3.5.1.yaml": component "canton-open-source" is currently not installed.  Run `dpm install package` to install
error handling component "codegen" in "/Users/jimmyjam/.dpm/cache/sdk/open-source/3.5.1.yaml": component "codegen" is currently not installed.  Run `dpm install package` to install
error handling component "daml-new" in "/Users/jimmyjam/.dpm/cache/sdk/open-source/3.5.1.yaml": component "daml-new" is currently not installed.  Run `dpm install package` to install
error handling component "daml-script" in "/Users/jimmyjam/.dpm/cache/sdk/open-source/3.5.1.yaml": component "daml-script" is currently not installed.  Run `dpm install package` to install
error handling component "daml-shell" in "/Users/jimmyjam/.dpm/cache/sdk/open-source/3.5.1.yaml": component "daml-shell" is currently not installed.  Run `dpm install package` to install
error handling component "damlc" in "/Users/jimmyjam/.dpm/cache/sdk/open-source/3.5.1.yaml": component "damlc" is currently not installed.  Run `dpm install package` to install
error handling component "scribe" in "/Users/jimmyjam/.dpm/cache/sdk/open-source/3.5.1.yaml": component "scribe" is currently not installed.  Run `dpm install package` to install
error handling component "upgrade-check" in "/Users/jimmyjam/.dpm/cache/sdk/open-source/3.5.1.yaml": component "upgrade-check" is currently not installed.  Run `dpm install package` to install
exit status 1
make: *** [Makefile:17: local-build] Error 1
```