### PR TITLE
Version comment in yaml

### DIFF
--- a/cmd/dpm/cmd/add/component/component.go
+++ b/cmd/dpm/cmd/add/component/component.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"daml.com/x/assistant/pkg/assembler"
@@ -13,11 +12,10 @@ import (
 	"daml.com/x/assistant/pkg/componentlist"
 	"daml.com/x/assistant/pkg/damlpackage"
 	"daml.com/x/assistant/pkg/multipackage"
+	"daml.com/x/assistant/pkg/ocilister"
 	"daml.com/x/assistant/pkg/ocipuller/remotepuller"
 	"daml.com/x/assistant/pkg/sdkmanifest"
 	"daml.com/x/assistant/pkg/yamledit"
-	"github.com/goccy/go-yaml"
-	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/registry"
@@ -83,7 +81,7 @@ func AddOrUpdateComponent(ctx context.Context, config *assistantconfig.Config, p
 	}
 
 	// Resolve to sha256
-	sha, err := GetDigest(ctx, client, ref)
+	sha, manifest, err := ocilister.FetchManifest(ctx, client, ref)
 	if err != nil {
 		return err
 	}
@@ -95,7 +93,15 @@ func AddOrUpdateComponent(ctx context.Context, config *assistantconfig.Config, p
 	}
 
 	// Edit daml.yaml / multi-package.yaml
-	if err := modifyYamlManifest(projectManifest, resolvedUri, index); err != nil {
+	yamlTarget := yamledit.YamlTarget{
+		YamlFilePath: projectManifest,
+		FieldName:    "components",
+		Index:        index,
+	}
+	if version := manifest.Annotations[v1.AnnotationVersion]; version != "" {
+		yamlTarget.LineComment = "# " + version
+	}
+	if err := yamledit.EditYaml(yamlTarget, resolvedUri); err != nil {
 		return err
 	}
 
@@ -113,26 +119,6 @@ func PullComponent(ctx context.Context, resolvedUri string, config *assistantcon
 	puller := remotepuller.New(config.OciLayoutCache, client)
 	_, err = assembler.New(config, puller).Assemble(ctx, m)
 	return err
-}
-
-func GetDigest(ctx context.Context, client *assistantremote.Remote, ref registry.Reference) (*digest.Digest, error) {
-	// TODO this function does a HEAD instead of GET
-	// and so the returned OCI descriptor isn't the full one would include all the annotations
-
-	fmt.Printf("Resolving %q...\n", ref.String())
-
-	repo, err := client.Repo(ref.Repository)
-	if err != nil {
-		return nil, err
-	}
-	desc, err := repo.Resolve(ctx, ref.Reference)
-	if err != nil {
-		return nil, err
-	}
-
-	fmt.Println("resolved sha256: " + desc.Digest)
-	fmt.Println("resolved version: " + desc.Annotations[v1.AnnotationVersion])
-	return &desc.Digest, nil
 }
 
 func asSdkManifest(uri string) (*sdkmanifest.SdkManifest, error) {
@@ -170,30 +156,6 @@ func getDamlYamlOrMultiPackageYaml() (string, string, error) {
 	}
 
 	return "", "", fmt.Errorf("not in a (single-package or multi-package) project directory")
-}
-
-func modifyYamlManifest(path, component string, index int) error {
-	b, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-
-	item, err := yaml.Marshal(&componentlist.ComponentEntry{StringBased: &component})
-	if err != nil {
-		return err
-	}
-
-	var out string
-	if index != -1 {
-		out, err = yamledit.ReplaceItemInList(b, "components", index, string(item))
-	} else {
-		out, err = yamledit.AddToList(b, "components", string(item))
-	}
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(path, []byte(out), 0644)
 }
 
 func findExistingComponent(components componentlist.ComponentList, uri string) (int, error) {

--- a/cmd/dpm/cmd/add/component/component.go
+++ b/cmd/dpm/cmd/add/component/component.go
@@ -53,12 +53,17 @@ func Cmd(config *assistantconfig.Config) *cobra.Command {
 				components = obj.ComponentsList
 			}
 
-			index, err := findExistingComponent(components, uri)
+			uriRef, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
+			if err != nil {
+				return err
+			}
+
+			index, err := findExistingComponent(components, uriRef)
 			if err != nil {
 				return err
 			}
 			if index != -1 {
-				fmt.Printf("component %q already exists, will be updated...\n", uri)
+				fmt.Printf("component 'oci://%s/%s' already exists, will be updated...\n", uriRef.Registry, uriRef.Repository)
 			}
 
 			return AddOrUpdateComponent(ctx, config, projectManifest, uri, insecure, index)
@@ -158,12 +163,7 @@ func getDamlYamlOrMultiPackageYaml() (string, string, error) {
 	return "", "", fmt.Errorf("not in a (single-package or multi-package) project directory")
 }
 
-func findExistingComponent(components componentlist.ComponentList, uri string) (int, error) {
-	uriRef, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
-	if err != nil {
-		return 0, err
-	}
-
+func findExistingComponent(components componentlist.ComponentList, uriRef registry.Reference) (int, error) {
 	for i, compEntry := range components {
 		if compEntry.StringBased == nil {
 			continue

--- a/cmd/dpm/cmd/add/dar/dar.go
+++ b/cmd/dpm/cmd/add/dar/dar.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
 	"strings"
 
 	project "daml.com/x/assistant/cmd/dpm/cmd/install/package"
@@ -13,6 +12,7 @@ import (
 	"daml.com/x/assistant/pkg/damlpackage"
 	"daml.com/x/assistant/pkg/ocilister"
 	"daml.com/x/assistant/pkg/yamledit"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/registry"
 )
@@ -48,14 +48,21 @@ func Cmd(config *assistantconfig.Config) *cobra.Command {
 				return err
 			}
 
+			yamlTarget := yamledit.YamlTarget{
+				YamlFilePath: damlPackagePath,
+				FieldName:    depsFieldName,
+				Index:        -1,
+			}
+
 			// update
 			if existingDep != nil {
 				fmt.Printf("dependency %q already exists in daml.yaml, will be updated...\n", uri)
-				return AddOrUpdateDar(ctx, config, damlPackagePath, uri, depsFieldName, insecure, existingDep.Index)
+				yamlTarget.Index = existingDep.Index
+				return AddOrUpdateDar(ctx, config, uri, insecure, yamlTarget)
 			}
 
 			// add
-			return AddOrUpdateDar(ctx, config, damlPackagePath, uri, depsFieldName, insecure, -1)
+			return AddOrUpdateDar(ctx, config, uri, insecure, yamlTarget)
 		},
 	}
 
@@ -111,7 +118,7 @@ func findExistingDependency(uri, depsFieldName string) (*damlpackage.ParsedDarDe
 }
 
 // AddOrUpdateDar will add when the passed index is -1, otherwise it will update at that index
-func AddOrUpdateDar(ctx context.Context, config *assistantconfig.Config, damlPackagePath, uri, depsFieldName string, insecure bool, index int) error {
+func AddOrUpdateDar(ctx context.Context, config *assistantconfig.Config, uri string, insecure bool, yamlTarget yamledit.YamlTarget) error {
 	ref, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
 	if err != nil {
 		return err
@@ -122,13 +129,13 @@ func AddOrUpdateDar(ctx context.Context, config *assistantconfig.Config, damlPac
 	}
 
 	// Resolve to sha256
-	resolvedDigest, _, err := ocilister.FetchManifest(ctx, client, ref)
+	resolvedDigest, manifest, err := ocilister.FetchManifest(ctx, client, ref)
 	if err != nil {
 		return err
 	}
+	yamlTarget.LineComment = manifest.Annotations[v1.AnnotationVersion]
 	resolvedUri := uri + "@" + resolvedDigest.String()
 
-	// Pull
 	parsedUrl, err := url.Parse(resolvedUri)
 	if err != nil {
 		return err
@@ -139,16 +146,16 @@ func AddOrUpdateDar(ctx context.Context, config *assistantconfig.Config, damlPac
 			Insecure: insecure,
 		},
 	}
-	if _, err := project.InstallDar(ctx, config, parsedDarDep); err != nil {
+	if _, _, err := project.InstallDar(ctx, config, parsedDarDep); err != nil {
 		return err
 	}
 
 	// Edit daml.yaml
-	if err := appendDarToYaml(damlPackagePath, depsFieldName, resolvedUri, index); err != nil {
+	if err := yamledit.EditYaml(yamlTarget, resolvedUri); err != nil {
 		return err
 	}
 
-	fmt.Printf("Successfully installed and added dar %q to %q\n", resolvedUri, damlPackagePath)
+	fmt.Printf("Successfully installed and added dar %q to %q\n", resolvedUri, yamlTarget.YamlFilePath)
 	return nil
 }
 
@@ -163,23 +170,4 @@ func dependenciesFieldFromArgs(dependencies, dataDependencies bool) (string, err
 		return "data-dependencies", nil
 	}
 	return "", fmt.Errorf("a --dependencies or --data-dependencies is required")
-}
-
-func appendDarToYaml(path, fieldName, dar string, index int) error {
-	b, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-
-	var out string
-	if index != -1 {
-		out, err = yamledit.ReplaceItemInList(b, fieldName, index, dar)
-	} else {
-		out, err = yamledit.AddToList(b, fieldName, dar)
-	}
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(path, []byte(out), 0644)
 }

--- a/cmd/dpm/cmd/add/dar/dar.go
+++ b/cmd/dpm/cmd/add/dar/dar.go
@@ -56,7 +56,12 @@ func Cmd(config *assistantconfig.Config) *cobra.Command {
 
 			// update
 			if existingDep != nil {
-				fmt.Printf("dependency %q already exists in daml.yaml, will be updated...\n", uri)
+				ref, err := registry.ParseReference(strings.TrimPrefix(uri, "oci://"))
+				if err != nil {
+					return err
+				}
+
+				fmt.Printf("dependency 'oci://%s/%s' already exists in daml.yaml, will be updated...\n", ref.Registry, ref.Reference)
 				yamlTarget.Index = existingDep.Index
 				return AddOrUpdateDar(ctx, config, uri, insecure, yamlTarget)
 			}

--- a/cmd/dpm/cmd/dpm_add_test.go
+++ b/cmd/dpm/cmd/dpm_add_test.go
@@ -118,6 +118,8 @@ data-dependencies:
 	assert.Equal(t, "std-lib", *damlPkg.DataDependencies[0].ValueOnly)
 	assert.Contains(t, *damlPkg.DataDependencies[1].ValueOnly, "oci://"+darRefLatest.String()+"@sha256:")
 	assert.NotContains(t, *damlPkg.DataDependencies[1].ValueOnly, oldSha256, "daml.yaml expected to not contain the old sha256 anymore")
+
+	assertContainsComment(t, filepath.Join(projectDir, "daml.yaml"), "# 4.5.6")
 }
 
 func (suite *MainSuite) TestDpmAddDarCommandNegativeCases() {
@@ -168,6 +170,14 @@ components:
 	assert.Equal(t, "pre-existing:1.2.3", *damlPkg.ComponentsList[0].StringBased)
 	assert.Contains(t, *damlPkg.ComponentsList[1].StringBased, "oci://"+compRefLatest+"@sha256:")
 	assert.NotContains(t, *damlPkg.ComponentsList[1].StringBased, oldSha256, "daml.yaml expected to not contain the old sha256 anymore")
+
+	assertContainsComment(t, filepath.Join(projectDir, "daml.yaml"), "# 4.5.6")
+}
+
+func assertContainsComment(t *testing.T, yamlFilePath, comment string) {
+	bytes, err := os.ReadFile(yamlFilePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(bytes), comment)
 }
 
 // tests 'dpm add component' for a component that already exists in daml.yaml
@@ -204,4 +214,6 @@ components:
 	assert.Equal(t, "pre-existing:1.2.3", *damlPkg.ComponentsList[0].StringBased)
 	assert.Contains(t, *damlPkg.ComponentsList[1].StringBased, "oci://"+newComponent+":4.5.6@sha256:")
 	assert.NotContains(t, *damlPkg.ComponentsList[1].StringBased, oldSha256, "daml.yaml expected to not contain the old sha256 anymore")
+
+	assertContainsComment(t, filepath.Join(projectDir, "daml.yaml"), "# 4.5.6")
 }

--- a/cmd/dpm/cmd/dpm_update_test.go
+++ b/cmd/dpm/cmd/dpm_update_test.go
@@ -87,6 +87,8 @@ components:
 
 		uriBeforeUpdate = *pkg.ComponentsList[0].StringBased
 		assert.Contains(t, uriBeforeUpdate, componentOciUri+":latest@sha256:")
+
+		assertContainsComment(t, filepath.Join(projectDir, "daml.yaml"), "# 1.1.1")
 	})
 
 	t.Run("update command bumps floaty components", func(t *testing.T) {
@@ -105,11 +107,15 @@ components:
 		assert.Contains(t, uriAfterUpdate, componentOciUri+":latest@sha256:")
 
 		assert.NotEqual(t, uriBeforeUpdate, uriAfterUpdate)
+
+		assertContainsComment(t, filepath.Join(projectDir, "daml.yaml"), "# 2.2.2")
 	})
 
 	t.Run("running dpm update more than once in a row", func(t *testing.T) {
 		cmd := createStdTestRootCmd(t, "update")
 		require.NoError(t, cmd.Execute())
+
+		assertContainsComment(t, filepath.Join(projectDir, "daml.yaml"), "# 2.2.2")
 	})
 }
 
@@ -149,6 +155,8 @@ data-dependencies:
 		valueBeforeUpdate, err = damlPkg.DataDependencies[1].Value()
 		require.NoError(t, err)
 		assert.Contains(t, valueBeforeUpdate, "latest@sha256")
+
+		assertContainsComment(t, filepath.Join(projectDir, "daml.yaml"), "# 1.1.1")
 	})
 
 	t.Run("update command should update floaty dars", func(t *testing.T) {
@@ -168,6 +176,8 @@ data-dependencies:
 
 		// make sure it's a different sha256 now
 		assert.NotEqual(t, valueAfterUpdate, valueBeforeUpdate)
+
+		assertContainsComment(t, filepath.Join(projectDir, "daml.yaml"), "# 2.2.2")
 	})
 
 }

--- a/cmd/dpm/cmd/install/package/package.go
+++ b/cmd/dpm/cmd/install/package/package.go
@@ -18,6 +18,7 @@ import (
 	"daml.com/x/assistant/pkg/ocipuller/remotepuller"
 	"daml.com/x/assistant/pkg/utils"
 	"daml.com/x/assistant/pkg/yamledit"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/samber/lo"
 
 	"daml.com/x/assistant/pkg/assistantconfig"
@@ -127,7 +128,7 @@ func processDamlPackage(ctx context.Context, cmd *cobra.Command, config *assista
 		YamlFilePath: damlPath,
 		FieldName:    "data-dependencies",
 	}
-	if err := installDars(ctx, config, lo.Values(damlPackage.ParsedDarDependencies.DataDependencies), yamlTarget); err != nil {
+	if err := installDars(ctx, config, lo.Values(damlPackage.ParsedDarDependencies.DataDependencies), yamlTarget.Copy()); err != nil {
 		return err
 	}
 
@@ -136,7 +137,7 @@ func processDamlPackage(ctx context.Context, cmd *cobra.Command, config *assista
 
 func installDars(ctx context.Context, config *assistantconfig.Config, dars []*damlpackage.ParsedDarDependency, yamlTarget yamledit.YamlTarget) error {
 	for _, d := range dars {
-		updatedDar, err := InstallDar(ctx, config, d)
+		updatedDar, version, err := InstallDar(ctx, config, d)
 		if err != nil {
 			return err
 		}
@@ -144,37 +145,39 @@ func installDars(ctx context.Context, config *assistantconfig.Config, dars []*da
 		// now update daml.yaml if we had to append a @sha256
 		if updatedDar != nil {
 			quotedUri := fmt.Sprintf("\"%s\"", updatedDar.StringWithAlias())
+			yamlTarget = yamlTarget.Copy()
 			yamlTarget.Index = updatedDar.Index
+			yamlTarget.LineComment = version
 			return yamledit.EditYaml(yamlTarget, quotedUri)
 		}
 	}
 	return nil
 }
 
-func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpackage.ParsedDarDependency) (updatedDar *damlpackage.ParsedDarDependency, err error) {
+func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpackage.ParsedDarDependency) (updatedDar *damlpackage.ParsedDarDependency, version string, err error) {
 	if dar.FullUrl.Scheme != "oci" {
-		return nil, nil
+		return nil, "", nil
 	}
 	fmt.Printf("installing dar %q...\n", dar.FullUrl.String())
 
 	client, ref, err := dar.GetOciRemote()
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if !assistantconfig.ShaPinningEnabled() && ocilister.IsFloaty(ref.Reference) {
-		return nil, fmt.Errorf("tag not allowed in %q: only strict semver OCI tags are supported currently", dar.FullUrl.String())
+		return nil, "", fmt.Errorf("tag not allowed in %q: only strict semver OCI tags are supported currently", dar.FullUrl.String())
 	}
 
 	if assistantconfig.ShaPinningEnabled() && !strings.Contains(dar.FullUrl.String(), "@sha256:") {
-		resolvedDigest, _, err := ocilister.FetchManifest(ctx, client, *ref)
+		resolvedDigest, manifest, err := ocilister.FetchManifest(ctx, client, *ref)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 
 		newUrl, err := url.Parse(dar.FullUrl.String() + "@" + resolvedDigest.String())
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		updatedDar = &damlpackage.ParsedDarDependency{
 			FullUrl:       newUrl,
@@ -183,9 +186,11 @@ func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpa
 			Index:         dar.Index,
 		}
 
+		version = manifest.Annotations[v1.AnnotationVersion]
+
 		client, ref, err = updatedDar.GetOciRemote()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 	}
 
@@ -194,17 +199,17 @@ func InstallDar(ctx context.Context, config *assistantconfig.Config, dar *damlpa
 
 	ok, err := utils.DirExists(darDir)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if ok {
 		fmt.Println("Dar already installed.")
-		return updatedDar, nil
+		return updatedDar, version, nil
 	}
 	if _, err = puller.PullDarByFullPath(ctx, ref.Repository, ref.Reference, darDir); err != nil {
-		return nil, err
+		return nil, version, err
 	}
 
-	return updatedDar, nil
+	return updatedDar, version, nil
 }
 
 func installMultiPackageYamlComponentsOnly(ctx context.Context, cmd *cobra.Command, config *assistantconfig.Config) error {

--- a/cmd/dpm/cmd/install_package_test.go
+++ b/cmd/dpm/cmd/install_package_test.go
@@ -214,6 +214,8 @@ components:
 		newContent, err := os.ReadFile(filepath.Join(projectDir, "daml.yaml"))
 		require.NoError(t, err)
 		assert.Contains(t, string(newContent), newComponent+"@"+resolvedDigest.String())
+
+		assertContainsComment(t, filepath.Join(projectDir, "daml.yaml"), "# 4.5.6")
 	})
 
 	t.Run("dpm resolve works for sha256 pinned oci components", func(t *testing.T) {
@@ -221,11 +223,15 @@ components:
 		comps := lo.Values(lo.Values(resolution.Packages)[0].ComponentsV2)
 		assert.Len(t, comps, 1)
 		assert.Equal(t, "4.5.6", comps[0]["version"])
+
+		assertContainsComment(t, filepath.Join(projectDir, "daml.yaml"), "# 4.5.6")
 	})
 
 	t.Run("dpm installing more than once", func(t *testing.T) {
 		cmd := createStdTestRootCmd(t, "install")
 		require.NoError(t, cmd.Execute())
+
+		assertContainsComment(t, filepath.Join(projectDir, "daml.yaml"), "# 4.5.6")
 	})
 }
 
@@ -261,11 +267,15 @@ components:
 		newContent, err := os.ReadFile(filepath.Join(projectDir, "multi-package.yaml"))
 		require.NoError(t, err)
 		assert.Contains(t, string(newContent), newComponent+"@"+resolvedDigest.String())
+
+		assertContainsComment(t, filepath.Join(projectDir, "multi-package.yaml"), "# 4.5.6")
 	})
 
 	t.Run("dpm installing more than once", func(t *testing.T) {
 		cmd := createStdTestRootCmd(t, "install")
 		require.NoError(t, cmd.Execute())
+
+		assertContainsComment(t, filepath.Join(projectDir, "multi-package.yaml"), "# 4.5.6")
 	})
 }
 

--- a/cmd/dpm/cmd/update/update.go
+++ b/cmd/dpm/cmd/update/update.go
@@ -16,6 +16,7 @@ import (
 	"daml.com/x/assistant/pkg/ocilister"
 	"daml.com/x/assistant/pkg/ocipuller/remotepuller"
 	"daml.com/x/assistant/pkg/sdkmanifest"
+	"daml.com/x/assistant/pkg/yamledit"
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/registry"
 )
@@ -138,13 +139,21 @@ func (c *updateCmd) updatePackage(ctx context.Context, damlPackage *damlpackage.
 	}
 
 	for _, dep := range damlPackage.ParsedDarDependencies.Dependencies {
-		if err := c.updateDar(ctx, damlPackage.AbsolutePath, "dependencies", dep); err != nil {
+		yamlTarget := yamledit.YamlTarget{
+			YamlFilePath: damlPackage.AbsolutePath,
+			FieldName:    "dependencies",
+		}
+		if err := c.updateDar(ctx, dep, yamlTarget); err != nil {
 			return err
 		}
 	}
 
 	for _, dep := range damlPackage.ParsedDarDependencies.DataDependencies {
-		if err := c.updateDar(ctx, damlPackage.AbsolutePath, "data-dependencies", dep); err != nil {
+		yamlTarget := yamledit.YamlTarget{
+			YamlFilePath: damlPackage.AbsolutePath,
+			FieldName:    "data-dependencies",
+		}
+		if err := c.updateDar(ctx, dep, yamlTarget); err != nil {
 			return err
 		}
 	}
@@ -152,7 +161,7 @@ func (c *updateCmd) updatePackage(ctx context.Context, damlPackage *damlpackage.
 	return nil
 }
 
-func (c *updateCmd) updateDar(ctx context.Context, damlPackagePath, field string, dep *damlpackage.ParsedDarDependency) error {
+func (c *updateCmd) updateDar(ctx context.Context, dep *damlpackage.ParsedDarDependency, yamlTarget yamledit.YamlTarget) error {
 	if dep.FullUrl.Scheme != "oci" {
 		return nil
 	}
@@ -174,7 +183,8 @@ func (c *updateCmd) updateDar(ctx context.Context, damlPackagePath, field string
 	}
 
 	insecure := c.forceInsecure || (dep.Location != nil && dep.Location.Insecure)
-	if err := dar.AddOrUpdateDar(ctx, c.config, damlPackagePath, uri, field, insecure, dep.Index); err != nil {
+	yamlTarget.Index = dep.Index
+	if err := dar.AddOrUpdateDar(ctx, c.config, uri, insecure, yamlTarget); err != nil {
 		return err
 	}
 

--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -494,7 +494,9 @@ func (a *Assembler) installUriComp(ctx context.Context, comp *sdkmanifest.Compon
 		if comp.YamlEditTarget == nil {
 			return "", fmt.Errorf("could not update project's daml.yaml or multi-package.yaml with component's sha for component %q as the needed info to edit the yaml file is missing", uri)
 		}
-		if err := yamledit.EditYaml(*comp.YamlEditTarget, newUri); err != nil {
+		yamlTarget := comp.YamlEditTarget.Copy()
+		yamlTarget.LineComment = version
+		if err := yamledit.EditYaml(yamlTarget, newUri); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/yamledit/testdata/empty/expected.yaml
+++ b/pkg/yamledit/testdata/empty/expected.yaml
@@ -4,5 +4,5 @@ blah: blah
 # whatever
 whatever: whatever
 components:
-  - name: newly-added
+  - name: newly-added # some foo comment
     path: /newly/added

--- a/pkg/yamledit/testdata/non-empty/expected.yaml
+++ b/pkg/yamledit/testdata/non-empty/expected.yaml
@@ -14,7 +14,7 @@ components:
   - some: oci://okay.com/whatever:9.9.9
     # another comment
     object: /dev/null
-  - name: newly-added
+  - name: newly-added # some foo comment
     path: /newly/added
 
 # whatever

--- a/pkg/yamledit/testdata/replace/last/expected.yaml
+++ b/pkg/yamledit/testdata/replace/last/expected.yaml
@@ -11,7 +11,7 @@ components:
   # some
   # multi-line
   # comments
-  - name: newly-added
+  - name: newly-added # some foo comment
     path: /newly/added
 
 # whatever

--- a/pkg/yamledit/testdata/replace/not-last/expected.yaml
+++ b/pkg/yamledit/testdata/replace/not-last/expected.yaml
@@ -4,7 +4,7 @@ blah: blah
 # some components stuffz
 components:
   # hehehe
-  - name: newly-added
+  - name: newly-added # some foo comment
     path: /newly/added
   # this is a meep
   - oci://foo.com/meep:1.2.3-meep

--- a/pkg/yamledit/yamledit.go
+++ b/pkg/yamledit/yamledit.go
@@ -1,7 +1,6 @@
 package yamledit
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"strings"
@@ -14,6 +13,17 @@ type YamlTarget struct {
 	YamlFilePath string
 	FieldName    string
 	Index        int
+
+	LineComment string
+}
+
+func (t *YamlTarget) Copy() YamlTarget {
+	return YamlTarget{
+		YamlFilePath: t.YamlFilePath,
+		FieldName:    t.FieldName,
+		Index:        t.Index,
+		LineComment:  t.LineComment,
+	}
 }
 
 // EditYaml adds an item to list in yaml file
@@ -23,6 +33,8 @@ func EditYaml(info YamlTarget, item string) error {
 	if err != nil {
 		return err
 	}
+
+	item = attachLineComment(item, info.LineComment)
 
 	var out string
 	if info.Index != -1 {
@@ -38,7 +50,7 @@ func EditYaml(info YamlTarget, item string) error {
 }
 
 // AddToList adds item to the given target field.
-// item can be a simple value or a whole object
+// item can be a simple value or a YAML object.
 func AddToList(raw []byte, field string, item string) (string, error) {
 	f, err := parser.ParseBytes(raw, parser.ParseComments)
 	if err != nil {
@@ -50,12 +62,17 @@ func AddToList(raw []byte, field string, item string) (string, error) {
 		return "", err
 	}
 
+	itemListFile, err := parser.ParseBytes(itemListYAML, parser.ParseComments)
+	if err != nil {
+		return "", err
+	}
+
 	path, err := yaml.PathString("$." + field)
 	if err != nil {
 		return "", err
 	}
 
-	err = path.MergeFromReader(f, bytes.NewReader(itemListYAML))
+	err = path.MergeFromFile(f, itemListFile)
 	if err == nil {
 		return f.String(), nil
 	}
@@ -67,15 +84,20 @@ func AddToList(raw []byte, field string, item string) (string, error) {
 	// field does not exist yet. Add:
 	//
 	// field:
-	//   - <item>
+	//   - <item> # <comment>
 	rootFragment := field + ":\n" + indentYaml(string(itemListYAML))
+
+	rootFragmentFile, err := parser.ParseBytes([]byte(rootFragment), parser.ParseComments)
+	if err != nil {
+		return "", err
+	}
 
 	root, err := yaml.PathString("$")
 	if err != nil {
 		return "", err
 	}
 
-	if err := root.MergeFromReader(f, strings.NewReader(rootFragment)); err != nil {
+	if err := root.MergeFromFile(f, rootFragmentFile); err != nil {
 		return "", err
 	}
 
@@ -83,11 +105,38 @@ func AddToList(raw []byte, field string, item string) (string, error) {
 }
 
 func marshalOneItemList(item string) ([]byte, error) {
-	var value any
-	if err := yaml.Unmarshal([]byte(item), &value); err != nil {
-		return nil, err
+	item = normalizeYAMLFragment(item)
+	if strings.TrimSpace(item) == "" {
+		return nil, fmt.Errorf("empty YAML item")
 	}
-	return yaml.MarshalWithOptions([]any{value}, yaml.Indent(2))
+
+	// Validate the raw item first.
+	if _, err := parser.ParseBytes([]byte(item), parser.ParseComments); err != nil {
+		return nil, fmt.Errorf("invalid YAML item: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(item, "\n"), "\n")
+	out := make([]string, len(lines))
+
+	out[0] = "- " + lines[0]
+	for i := 1; i < len(lines); i++ {
+		out[i] = "  " + lines[i]
+	}
+
+	seq := []byte(strings.Join(out, "\n") + "\n")
+
+	// Validate the generated one-item sequence too.
+	if _, err := parser.ParseBytes(seq, parser.ParseComments); err != nil {
+		return nil, fmt.Errorf("invalid YAML list item: %w", err)
+	}
+
+	return seq, nil
+}
+
+func normalizeYAMLFragment(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.Trim(s, "\n")
+	return s + "\n"
 }
 
 func indentYaml(s string) string {
@@ -96,6 +145,23 @@ func indentYaml(s string) string {
 		lines[i] = "  " + lines[i]
 	}
 	return strings.Join(lines, "\n") + "\n"
+}
+
+func attachLineComment(item, comment string) string {
+	comment = strings.TrimSpace(comment)
+	if comment == "" {
+		return item
+	}
+
+	comment = strings.TrimSpace(strings.TrimPrefix(comment, "#"))
+	if comment == "" {
+		return item
+	}
+
+	item = strings.TrimRight(item, "\n")
+	lines := strings.Split(item, "\n")
+	lines[0] = strings.TrimRight(lines[0], " \t") + " # " + comment
+	return strings.Join(lines, "\n")
 }
 
 // ReplaceItemInList replaces the specified item in given field.
@@ -115,7 +181,14 @@ func replace(raw []byte, path string, replacement string) (string, error) {
 		return "", err
 	}
 
-	if err := p.ReplaceWithReader(f, bytes.NewBufferString(replacement)); err != nil {
+	replacement = normalizeYAMLFragment(replacement)
+
+	replacementFile, err := parser.ParseBytes([]byte(replacement), parser.ParseComments)
+	if err != nil {
+		return "", fmt.Errorf("invalid YAML replacement: %w", err)
+	}
+
+	if err := p.ReplaceWithFile(f, replacementFile); err != nil {
 		return "", err
 	}
 

--- a/pkg/yamledit/yamledit_test.go
+++ b/pkg/yamledit/yamledit_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const item = `name: newly-added
-path: /newly/added`
+var item = attachLineComment(`name: newly-added
+path: /newly/added`, "# some foo comment")
 
 func TestAddToList(t *testing.T) {
 	t.Run("non-empty list", func(t *testing.T) {


### PR DESCRIPTION
dpm will now include `# <semver>` comment next to the component / dar URI in the `daml.yaml` / `multi-package.yaml` when it running any of the `add` / `install` / `update` commands

```
cat /var/folders/df/x806g1dd1v3b956tklkp5trc0000gq/T/TestSuiteTestAddingExistingComponentWithFloatyTagBumpsToNewerVe3513982764/001/daml.yaml
components:
  - pre-existing:1.2.3
  - oci://127.0.0.1:49263/newly/added:latest@sha256:88c48bf9679d591aa2625b39d1946c26b265162612a41e8ca50a2f085d6d2af8 # 4.5.6
```