### PR TITLE
fix: 🐛 Add lockfile dependencies to `resolved-dependencies` instead of `resolved-data-dependencies`

### DIFF
--- a/pkg/darpuller/darpuller.go
+++ b/pkg/darpuller/darpuller.go
@@ -2,8 +2,6 @@ package darpuller
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -19,7 +17,6 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
-	"oras.land/oras-go/v2/registry"
 )
 
 type OciDarPuller struct {
@@ -76,7 +73,9 @@ func (a *OciDarPuller) doPullDar(ctx context.Context, dar *damlpackage.ParsedDar
 		return nil, err
 	}
 
-	destPath := a.getPath(ref, version)
+	digestRef := *ref
+	digestRef.Reference = desc.Digest.String()
+	destPath := a.config.CachePathForDar(&digestRef)
 
 	ok, err := utils.DirExists(destPath)
 	if err != nil {
@@ -127,16 +126,6 @@ func (a *OciDarPuller) getVersion(ctx context.Context, repo oras.ReadOnlyTarget,
 		return nil, fmt.Errorf("version annotation %q in image manifest isn't a strict semver: %w", v, err)
 	}
 	return ver, nil
-}
-
-func (a *OciDarPuller) getPath(ref *registry.Reference, version *semver.Version) string {
-	// TODO maybe use a more human-readable path (but be sure to sanitize to not fail on Windows)
-	sha := sha256.Sum256([]byte(fmt.Sprintf("%s/%s:%s", ref.Registry, ref.Repository, version.String())))
-	return filepath.Join(
-		a.config.CachePath,
-		"dars",
-		hex.EncodeToString(sha[:]),
-	)
 }
 
 func getAnnotations(ctx context.Context, repo oras.ReadOnlyTarget, desc v1.Descriptor) (map[string]string, error) {

--- a/pkg/darpuller/darpuller_test.go
+++ b/pkg/darpuller/darpuller_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -47,6 +48,7 @@ func TestOciDarPuller(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, pulledDar.DarFilePath)
 	assert.NotEmpty(t, pulledDar.Descriptor.Digest)
+	assert.Contains(t, pulledDar.PulledImagePath, filepath.Join("dars", "sha256", strings.TrimPrefix(pulledDar.Descriptor.Digest.String(), "sha256:")))
 	assert.Equal(t, version, pulledDar.Version.String())
 }
 

--- a/pkg/resolver/deepresolver.go
+++ b/pkg/resolver/deepresolver.go
@@ -123,11 +123,21 @@ func (d *DeepResolver) resolvePackageAndDars(ctx context.Context, absPath string
 		return nil, err
 	}
 
-	paths := lo.Map(lock.Dars, func(d *packagelock.Dar, _ int) string {
-		return d.Path
+	lockedDeps := lo.FilterMap(lock.Dars, func(d *packagelock.Dar, _ int) (string, bool) {
+		// For now, the lockfile only contains builtin and OCI dependencies, it doesn't
+		// store local path dependencies. If support is added for local path deps or other
+		// kinds of dependencies, this will need to be updated.
+		if d.URI == nil || d.Path == "" {
+			return "", false
+		}
+		return d.Path, d.URI.Scheme == "builtin" || d.URI.Scheme == "oci"
 	})
-	if len(paths) > 0 {
-		result.ShallowResolution.Imports[resolution.DarImportsFields] = paths
+	if len(lockedDeps) > 0 {
+		resolvedDeps := result.ShallowResolution.Imports[resolution.ResolvedDependenciesField]
+
+		// De-duplicate the dependencies, in case the lockfile contains resolved dependencies
+		// that the resolver already got from `d.resolvePackageDars()`.
+		result.ShallowResolution.Imports[resolution.ResolvedDependenciesField] = lo.Uniq(append(resolvedDeps, lockedDeps...))
 	}
 
 	return result.ShallowResolution, nil


### PR DESCRIPTION
## Summary

This fixes two issues that I've observed in the experimental `dpm.lock` flow:

- Lockfile entries from `daml.yaml` `dependencies` were written to `resolved-data-dependencies`, causing builtin dependencies such as `daml-prim` to be passed to `damlc` as data dependencies and failing to build with `DPM_LOCKFILE_ENABLED=true dpm build --all`.
- Lockfile creation pulled OCI DARs into a separate cache layout from `dpm add` / `dpm install`, so the same OCI dependency appeared twice in the resolved dependencies file, with two different local paths.

**If I've misinterpreted these issues and in fact they (or some of them) were expected behaviours, happy to stand corrected.**

## Solution

- Treat `dpm.lock` `dars` entries as package dependencies and merge supported `builtin`/`oci` entries into `resolved-dependencies`, leaving `resolved-data-dependencies` to the normal `data-dependencies` resolver path.
- Deduplicate the final `resolved-dependencies` list after merging normal resolution output with lockfile output.
- Make the lockfile DAR puller use the same digest-addressed cache path as `dpm add` and `dpm install`: `~/.dpm/cache/dars/sha256/<digest>/...`.

## Before / After

Before, `DPM_LOCKFILE_ENABLED=true dpm resolve` placed lockfile dependencies in `resolved-data-dependencies`:

```yaml
imports:
  resolved-data-dependencies:
    - daml-prim
    - daml-script
    - daml-stdlib
    - /Users/.../.dpm/cache/dars/.../oci-dependency-interfaces-1.0.0.dar
  resolved-dependencies:
    - daml-script
    - /Users/.../.dpm/cache/dars/sha256/5fcc.../oci-dependency-interfaces-1.0.0.dar
    - daml-prim
    - daml-stdlib
```

That also meant `DPM_LOCKFILE_ENABLED=true dpm build --all` failed to compile with:

```text
Invalid package ID dependency in daml.yaml: daml-prim
```

After, lockfile-backed package dependencies stay in `resolved-dependencies`, and real `data-dependencies` remain separate:

```yaml
imports:
  resolved-data-dependencies:
    - /Users/.../interfaces/.daml/dist/oci-dep-consumer-interfaces-1.0.0.dar
    - /Users/.../main/.daml/dist/oci-dep-consumer-main-1.0.0.dar
  resolved-dependencies:
    - daml-prim
    - daml-stdlib
    - daml-script
    - /Users/.../.dpm/cache/dars/sha256/5fcc.../oci-dependency-interfaces-1.0.0.dar
```

The OCI DAR now appears once, using the same digest-based cache path produced by `dpm add`. And the project **builds successfully** with `DPM_LOCKFILE_ENABLED=true dpm build --all`.

## Reproducing the Issues

I've created a minimal reproduction repo with two Daml multi-package projects:

```sh
git clone https://github.com/ffarall/dpm-examples.git
cd dpm-examples/examples/oci-dep-consumer
```

Generate lockfiles and inspect resolution:

```sh
DPM_LOCKFILE_ENABLED=true dpm version --active
DPM_LOCKFILE_ENABLED=true dpm resolve
```

Before this fix:

- `resolved-data-dependencies` incorrectly included `daml-prim`, `daml-stdlib`, and OCI package dependencies from `dpm.lock`.
- OCI dependencies could appear twice in `resolved-dependencies`, once from the digest cache and once from the lockfile puller cache.
- `DPM_LOCKFILE_ENABLED=true dpm build --all` failed with the invalid `daml-prim` data dependency error.

After this fix:

```sh
DPM_LOCKFILE_ENABLED=true dpm build --all
```

builds successfully, and `DPM_LOCKFILE_ENABLED=true dpm resolve` keeps package dependencies and data dependencies in their correct fields.